### PR TITLE
[#1] ShazamService 구현

### DIFF
--- a/AGAMI/.swiftlint.yml
+++ b/AGAMI/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
   - line_length
   - trailing_whitespace
+  - trailing_newline
 
 opt_in_rules:
   - empty_count

--- a/AGAMI/Sources/Presentation/View/HomeView.swift
+++ b/AGAMI/Sources/Presentation/View/HomeView.swift
@@ -19,7 +19,6 @@ struct HomeView: View {
                 Tab("Shazam", systemImage: "shazam.logo", value: .shazam) {
                     ShazamHomeView()
                 }
-
             }
         } else {
             TabView {
@@ -31,6 +30,7 @@ struct HomeView: View {
                         }
                     }
                     .tag(TabSelection.music)
+
                 ShazamHomeView()
                     .tabItem {
                         VStack {

--- a/AGAMI/Sources/Presentation/View/HomeView.swift
+++ b/AGAMI/Sources/Presentation/View/HomeView.swift
@@ -10,9 +10,6 @@ import SwiftUI
 struct HomeView: View {
     @State private var selectedTab: TabSelection = .music
     var body: some View {
-        Button("shazam") {
-            selectedTab = .shazam
-        }
         if #available(iOS 18.0, *) {
             TabView(selection: $selectedTab) {
                 Tab("Music", systemImage: "music.note", value: .music) {

--- a/AGAMI/Sources/Presentation/View/ShazamHomeView.swift
+++ b/AGAMI/Sources/Presentation/View/ShazamHomeView.swift
@@ -10,7 +10,7 @@ import ShazamKit
 import AVKit
 
 struct ShazamHomeView: View {
-    @State private var viewModel = ViewModel()
+    @State private var viewModel = ShazamViewModel()
 
     var body: some View {
         NavigationView {
@@ -42,93 +42,6 @@ struct ShazamHomeView: View {
             }
             .padding()
             .navigationTitle("Shazam")
-        }
-    }
-}
-
-@Observable
-final class ViewModel: NSObject {
-    var currentItem: SHMediaItem?
-    var shazaming = false
-
-    @ObservationIgnored private let session = SHSession()
-    @ObservationIgnored private let audioEngine = AVAudioEngine()
-    @ObservationIgnored private var timer: Timer?
-
-    override init() {
-        super.init()
-        session.delegate = self
-    }
-
-    private func startTimer() {
-        dump(#function)
-        timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
-            dump("10초 지났다! 샤잠 꺼")
-            self?.stopRecognition()
-        }
-    }
-    private func stopTimer() {
-        dump(#function)
-        timer?.invalidate()
-        timer = nil
-    }
-
-    private func prepareAudioRecording() throws {
-        dump(#function)
-        let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.record)
-        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
-    }
-
-    private func generateSignature() {
-        dump(#function)
-        let inputNode = audioEngine.inputNode
-        let recordingFormat = inputNode.outputFormat(forBus: .zero)
-
-        inputNode.installTap(onBus: .zero, bufferSize: 1024, format: recordingFormat) { [weak session] buffer, _ in
-            session?.matchStreamingBuffer(buffer, at: nil)
-        }
-    }
-
-    private func startAudioRecording() throws {
-        dump(#function)
-        try audioEngine.start()
-        shazaming = true
-    }
-
-    func startRecognition() {
-        dump(#function)
-        do {
-            if audioEngine.isRunning {
-                stopRecognition()
-                return
-            }
-
-            try prepareAudioRecording()
-            generateSignature()
-            try startAudioRecording()
-            startTimer()
-        } catch {
-            dump(error.localizedDescription)
-        }
-    }
-
-    func stopRecognition() {
-        dump(#function)
-        shazaming = false
-        audioEngine.stop()
-        audioEngine.inputNode.removeTap(onBus: .zero)
-        stopTimer()
-    }
-}
-
-extension ViewModel: SHSessionDelegate {
-    func session(_ session: SHSession, didFind match: SHMatch) {
-        dump(#function)
-        guard let mediaItem = match.mediaItems.first else { return }
-        DispatchQueue.main.async { [weak self] in
-            self?.stopRecognition()
-            self?.currentItem = mediaItem
         }
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/ShazamHomeViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/ShazamHomeViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  ShazamViewModel.swift
+//  AGAMI
+//
+//  Created by 박현수 on 10/10/24.
+//
+
+import Foundation
+import ShazamKit
+
+@MainActor
+@Observable
+final class ShazamViewModel: NSObject {
+    var currentItem: SHMediaItem?
+    var shazaming = false
+
+    private let shazamService = ShazamService()
+
+    override init() {
+        super.init()
+        shazamService.delegate = self
+    }
+
+    func startRecognition() {
+        shazaming = true
+        shazamService.startRecognition()
+    }
+
+    func stopRecognition() {
+        shazaming = false
+        shazamService.stopRecognition()
+    }
+}
+
+extension ShazamViewModel: ShazamServiceDelegate {
+    func shazamService(_ service: ShazamService, didFind match: SHMatch) {
+        dump(#function)
+        guard let mediaItem = match.mediaItems.first else { return }
+        dump("title: \(mediaItem.title ?? "")")
+        stopRecognition()
+        currentItem = mediaItem
+    }
+
+    nonisolated func shazamService(_ service: ShazamService, didNotFindMatchFor signature: SHSignature, error: (any Error)?) {
+        dump(#function)
+        dump("didNotFindMatch | signature: \(signature) | error: \(String(describing: error))")
+    }
+
+    func shazamService(_ service: ShazamService, didFailWithError error: any Error) {
+        dump(#function)
+        stopRecognition()
+    }
+}

--- a/AGAMI/Sources/Service/ShazamService.swift
+++ b/AGAMI/Sources/Service/ShazamService.swift
@@ -4,5 +4,105 @@
 //
 //  Created by 박현수 on 10/10/24.
 //
-
 import Foundation
+import ShazamKit
+import AVKit
+
+protocol ShazamServiceDelegate: AnyObject {
+    @MainActor func shazamService(_ service: ShazamService, didFind match: SHMatch)
+    func shazamService(_ service: ShazamService, didNotFindMatchFor signature: SHSignature, error: (any Error)?)
+    @MainActor func shazamService(_ service: ShazamService, didFailWithError error: Error)
+}
+
+final class ShazamService: NSObject {
+    weak var delegate: ShazamServiceDelegate?
+
+    private let session = SHSession()
+    private let audioEngine = AVAudioEngine()
+    private var timer: Timer?
+
+    override init() {
+        super.init()
+        session.delegate = self
+    }
+
+    func startRecognition() {
+        dump(#function)
+        do {
+            if audioEngine.isRunning {
+                stopRecognition()
+                return
+            }
+
+            try prepareAudioRecording()
+            generateSignature()
+            try startAudioRecording()
+            startTimer()
+        } catch {
+            Task { @MainActor in
+                self.delegate?.shazamService(self, didFailWithError: error)
+            }
+        }
+    }
+
+    func stopRecognition() {
+        dump(#function)
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: .zero)
+        stopTimer()
+    }
+
+    private func prepareAudioRecording() throws {
+        dump(#function)
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    private func generateSignature() {
+        dump(#function)
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: .zero)
+
+        inputNode.installTap(onBus: .zero, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+            self?.session.matchStreamingBuffer(buffer, at: nil)
+        }
+    }
+
+    private func startAudioRecording() throws {
+        dump(#function)
+        try audioEngine.start()
+    }
+
+    private func startTimer() {
+        dump(#function)
+        timer = Timer.scheduledTimer(withTimeInterval: 20, repeats: true) { [weak self] _ in
+            dump("20초 경과 샤잠 종료")
+            self?.stopRecognition()
+        }
+    }
+
+    private func stopTimer() {
+        dump(#function)
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+extension ShazamService: SHSessionDelegate {
+    func session(_ session: SHSession, didFind match: SHMatch) {
+        Task { @MainActor in
+            self.delegate?.shazamService(self, didFind: match)
+        }
+    }
+
+    func session(_ session: SHSession, didNotFindMatchFor signature: SHSignature, error: (any Error)?) {
+        self.delegate?.shazamService(self, didNotFindMatchFor: signature, error: error)
+    }
+
+    func session(_ session: SHSession, didFailWithError error: Error) {
+        Task { @MainActor in
+            self.delegate?.shazamService(self, didFailWithError: error)
+        }
+    }
+}


### PR DESCRIPTION
## ✅ Description
- ShazamService 구현

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- swiftlint disabled_rules에 trailing_newline 추가했는데 계속 Tuist Derived 파일에 lint warning이 뜨네요,, 찾아봤으나 별 소득 없음
- Shazam 기능들 Service 레이어로 별도 분리했습니다. SHSessionDelegate 메소드들은 커스텀 델리게이트 패턴으로 VM에서 끌어다 쓸 수 있도록 했습니다
- didFind 메소드가 실행된 이후에도 UI 업데이트가 이루어지지 않는 버그가 종종 발생하는 것을 발견하고 UI에 연관된 데이터들은 메인 쓰레드에서만 접근될 수 있도록 수정했습니다. GCD로 때우려다 Swift Concurrency에 조금 익숙해져보고자 `Task`와 `@MainActor`를 사용했습니다.
```swift
var songs: [Song] // An array of MusicKit song objects that represent the song.
var appleMusicURL: URL? // A link to the Apple Music page that contains the full information for the song.
var appleMusicID: String? // The Apple Music ID for the song.
var matchOffset: TimeInterval // The timecode in the reference recording that matches the start of the query, in seconds.
```
 - `SHMatchedMediaItem`에서 MusicKit과 연관된 프로퍼티들입니다. 추후 기능 확실히 정해지면 해당 프로퍼티들 빼내는 메소드 작성하겠습니다.
## 📸 Simulator

https://github.com/user-attachments/assets/a69ecce5-d87a-4a54-90d6-5349e551eb4e


## 💡 Issue
- Resolved: #1 
