### PR TITLE
[#9] Archive 탭 UI 구현

### DIFF
--- a/AGAMI/Sources/App/AGAMIApp.swift
+++ b/AGAMI/Sources/App/AGAMIApp.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct AGAMIApp: App {
     var body: some Scene {
         WindowGroup {
-            HomeView()
+//            HomeView()
+            ArchiveListView()
         }
     }
 }

--- a/AGAMI/Sources/App/AGAMIApp.swift
+++ b/AGAMI/Sources/App/AGAMIApp.swift
@@ -4,8 +4,7 @@ import SwiftUI
 struct AGAMIApp: App {
     var body: some Scene {
         WindowGroup {
-//            HomeView()
-            ArchiveListView()
+            HomeView()
         }
     }
 }

--- a/AGAMI/Sources/Coordinator/ArchiveCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/ArchiveCoordinator.swift
@@ -1,0 +1,87 @@
+//
+//  ArchiveCoordinator.swift
+//  AGAMI
+//
+//  Created by 박현수 on 10/15/24.
+//
+
+import Foundation
+import SwiftUI
+
+enum ArchiveView: Hashable {
+    case listView
+    case playlistView
+}
+
+enum ArchiveSheet: String, Identifiable {
+    var id: String { self.rawValue }
+
+    case dummySheet
+}
+
+enum ArchiveFullScreenCover: String, Identifiable {
+    var id: String { self.rawValue }
+
+    case dummyFullScreenCover
+}
+
+@Observable
+final class ArchiveCoordinator {
+    var path: NavigationPath = .init()
+    var sheet: ArchiveSheet?
+    var fullScreenCover: ArchiveFullScreenCover?
+
+    func push(view: ArchiveView) {
+        path.append(view)
+    }
+
+    func pop() {
+        path.removeLast()
+    }
+
+    func popToRoot() {
+        path.removeLast(path.count)
+    }
+
+    func presentSheet(_ sheet: ArchiveSheet) {
+        self.sheet = sheet
+    }
+
+    func presentFullScreenCover(_ cover: ArchiveFullScreenCover) {
+        self.fullScreenCover = cover
+    }
+
+    func dismissSheet() {
+        self.sheet = nil
+    }
+
+    func dismissFullScreenCover() {
+        self.fullScreenCover = nil
+    }
+
+    @ViewBuilder
+    func build(view: ArchiveView) -> some View {
+        switch view {
+        case .listView:
+            ArchiveListView()
+        case .playlistView:
+            ArchivePlaylistView()
+        }
+    }
+
+    @ViewBuilder
+    func buildSheet(sheet: ArchiveSheet) -> some View {
+        switch sheet {
+        case .dummySheet:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    func buildFullScreenCover(cover: ArchiveFullScreenCover) -> some View {
+        switch cover {
+        case .dummyFullScreenCover:
+            EmptyView()
+        }
+    }
+}

--- a/AGAMI/Sources/Presentation/View/Archive/ArchiveListView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchiveListView.swift
@@ -1,0 +1,129 @@
+//
+//  ArchiveListView.swift
+//  AGAMI
+//
+//  Created by 박현수 on 10/14/24.
+//
+
+import SwiftUI
+
+struct ArchiveListView: View {
+    @State var viewModel: ArchiveListViewModel = .init()
+    @Namespace private var animationID
+
+    var body: some View {
+        GeometryReader {
+            let size = $0.size
+
+            ZStack(alignment: .top) {
+
+                ArchiveList(
+                    viewModel: viewModel,
+                    size: size,
+                    animationID: animationID
+                )
+
+                PopupView(
+                    viewModel: viewModel,
+                    size: size,
+                    animationID: animationID
+                )
+
+            }
+            .animation(.default, value: viewModel.currentId)
+        }
+        .safeAreaPadding(.horizontal, 40)
+        .onChange(of: viewModel.currentId) { _, _ in
+            viewModel.setSelectedCard(nil)
+        }
+    }
+}
+
+private struct ArchiveList: View {
+    @Bindable var viewModel: ArchiveListViewModel
+    let size: CGSize
+    let animationID: Namespace.ID
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            LazyVStack(spacing: 0) {
+                ForEach(0..<10, id: \.self) { index in
+                    ArchiveListCell(
+                        viewModel: viewModel,
+                        index: index,
+                        size: size,
+                        animationID: animationID
+                    )
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
+        .scrollPosition(id: $viewModel.currentId)
+        .safeAreaPadding(.top, (size.height - size.width) / 2)
+    }
+}
+
+private struct ArchiveListCell: View {
+    let viewModel: ArchiveListViewModel
+    let index: Int
+    let size: CGSize
+    let animationID: Namespace.ID
+
+    var body: some View {
+        AsyncImage(url: viewModel.dummyURL) { image in
+            image.resizable()
+        } placeholder: {
+            ProgressView()
+        }
+        .frame(width: size.width, height: size.width)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(radius: 10)
+        .matchedGeometryEffect(id: index, in: animationID)
+        .padding(.vertical, viewModel.getCardsPadding(index, size: size))
+        .onTapGesture {
+            if viewModel.isCurrent(index) {
+                withAnimation {
+                    viewModel.setSelectedCard(index)
+                }
+            } else {
+                withAnimation {
+                    viewModel.setCurrentId(index)
+                }
+
+            }
+        }
+    }
+
+}
+
+private struct PopupView: View {
+    let viewModel: ArchiveListViewModel
+    let size: CGSize
+    let animationID: Namespace.ID
+
+    var body: some View {
+        if let selected = viewModel.selectedCard {
+            VStack(spacing: 0) {
+                AsyncImage(url: viewModel.dummyURL) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: size.width, height: size.width)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .matchedGeometryEffect(id: selected, in: animationID)
+                .onTapGesture {
+                    viewModel.setSelectedCard(nil)
+                }
+                .padding(.top, 50)
+                Spacer()
+            }
+        }
+    }
+
+}
+
+#Preview {
+    ArchiveListView()
+}

--- a/AGAMI/Sources/Presentation/View/Archive/ArchiveListView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchiveListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ArchiveListView: View {
-    @State var viewModel: ArchiveListViewModel = .init()
+    @State var viewModel: ArchiveListViewModel = ArchiveListViewModel()
     @Namespace private var animationID
 
     var body: some View {
@@ -16,7 +16,6 @@ struct ArchiveListView: View {
             let size = $0.size
 
             ZStack(alignment: .top) {
-
                 ArchiveList(
                     viewModel: viewModel,
                     size: size,
@@ -28,7 +27,6 @@ struct ArchiveListView: View {
                     size: size,
                     animationID: animationID
                 )
-
             }
             .animation(.default, value: viewModel.currentId)
         }
@@ -96,7 +94,6 @@ private struct ArchiveListCell: View {
             }
         }
     }
-
 }
 
 private struct PopupView: View {
@@ -108,9 +105,7 @@ private struct PopupView: View {
 
     var body: some View {
         if let selected = viewModel.selectedCard {
-
             ZStack {
-
                 Color.black.opacity(0.4)
                     .ignoresSafeArea()
                     .onTapGesture {
@@ -132,12 +127,9 @@ private struct PopupView: View {
                     .padding(.top, 50)
                     Spacer()
                 }
-
             }
-
         }
     }
-
 }
 
 #Preview {

--- a/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
@@ -1,0 +1,121 @@
+//
+//  ArchivePlaylistView.swift
+//  AGAMI
+//
+//  Created by 박현수 on 10/15/24.
+//
+
+import SwiftUI
+
+struct ArchivePlaylistView: View {
+    @State var viewModel: ArchivePlaylistViewModel = .init()
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                PlaylistImageCellView(viewModel: viewModel)
+                TitleAndDescriptionView(viewModel: viewModel)
+                PlaylistView(viewModel: viewModel)
+            }
+        }
+        .toolbar { EditButton() }
+    }
+}
+
+private struct PlaylistImageCellView: View {
+    let viewModel: ArchivePlaylistViewModel
+
+    var body: some View {
+        AsyncImage(url: viewModel.dummyURL) { image in
+            image
+                .resizable()
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .aspectRatio(1, contentMode: .fit)
+                .padding(.horizontal, 20)
+                .shadow(radius: 10)
+        } placeholder: {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.white)
+                .aspectRatio(1, contentMode: .fit)
+                .padding(.horizontal, 20)
+                .shadow(radius: 10)
+        }
+        .padding(.top, 20)
+    }
+}
+
+private struct TitleAndDescriptionView: View {
+    let viewModel: ArchivePlaylistViewModel
+
+    var body: some View {
+        HStack {
+            Text(viewModel.playlistTitle)
+                .font(.system(size: 32, weight: .bold))
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 40)
+
+        Text(viewModel.playlistDescription)
+            .font(.system(size: 15))
+            .foregroundStyle(.gray)
+            .padding(10)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+    }
+}
+
+private struct PlaylistView: View {
+    @Bindable var viewModel: ArchivePlaylistViewModel
+
+    var body: some View {
+        HStack {
+            Text("플레이리스트")
+                .font(.system(size: 20, weight: .semibold))
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 28)
+
+        Divider()
+            .padding(.top, 10)
+
+        List {
+            ForEach(viewModel.dummyPlaylist) { song in
+                HStack {
+                    AsyncImage(url: song.imageURL) { image in
+                        image
+                            .resizable()
+                            .frame(width: 60, height: 60)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                    } placeholder: {
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(.black)
+                            .frame(width: 60, height: 60)
+                    }
+                    .padding(.trailing, 10)
+
+                    VStack(alignment: .leading) {
+                        Text(song.title)
+                            .font(.system(size: 20))
+                        Text(song.artist)
+                            .font(.system(size: 16))
+                            .foregroundStyle(.gray)
+                    }
+                }
+            }
+            .onDelete(perform: viewModel.deleteMusic)
+            .onMove(perform: viewModel.moveMusic)
+        }
+        .listStyle(.plain)
+        .scrollDisabled(true)
+        .scaledToFit()
+    }
+}
+
+#Preview {
+    ArchivePlaylistView()
+}

--- a/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
@@ -8,17 +8,19 @@
 import SwiftUI
 
 struct ArchivePlaylistView: View {
-    @State var viewModel: ArchivePlaylistViewModel = .init()
+    @State var viewModel: ArchivePlaylistViewModel = ArchivePlaylistViewModel()
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
+            VStack(spacing: 0) {
                 PlaylistImageCellView(viewModel: viewModel)
                 TitleAndDescriptionView(viewModel: viewModel)
                 PlaylistView(viewModel: viewModel)
+                    .scrollDisabled(true)
             }
+            .toolbar { EditButton() }
         }
-        .toolbar { EditButton() }
+
     }
 }
 
@@ -111,7 +113,6 @@ private struct PlaylistView: View {
             .onMove(perform: viewModel.moveMusic)
         }
         .listStyle(.plain)
-        .scrollDisabled(true)
         .scaledToFit()
     }
 }

--- a/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
@@ -16,7 +16,6 @@ struct ArchivePlaylistView: View {
                 PlaylistImageCellView(viewModel: viewModel)
                 TitleAndDescriptionView(viewModel: viewModel)
                 PlaylistView(viewModel: viewModel)
-                    .scrollDisabled(true)
             }
             .toolbar { EditButton() }
         }

--- a/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
@@ -34,13 +34,13 @@ private struct PlaylistImageCellView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 16))
                 .aspectRatio(1, contentMode: .fit)
                 .padding(.horizontal, 20)
-                .shadow(radius: 10)
+                .shadow(color: .black.opacity(0.25), radius: 8, x: 0, y: 4)
         } placeholder: {
             RoundedRectangle(cornerRadius: 16)
                 .fill(.white)
                 .aspectRatio(1, contentMode: .fit)
                 .padding(.horizontal, 20)
-                .shadow(radius: 10)
+                .shadow(color: .black.opacity(0.25), radius: 8, x: 0, y: 4)
         }
         .padding(.top, 20)
     }

--- a/AGAMI/Sources/Presentation/View/HomeView.swift
+++ b/AGAMI/Sources/Presentation/View/HomeView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     @State private var selectedTab: TabSelection = .music
+    @State var archiveCoord: ArchiveCoordinator = .init()
     var body: some View {
         if #available(iOS 18.0, *) {
             TabView(selection: $selectedTab) {
@@ -17,7 +18,19 @@ struct HomeView: View {
                 }
 
                 Tab("Archive", systemImage: "archivebox.fill", value: .shazam) {
-                    ShazamHomeView()
+                    NavigationStack(path: $archiveCoord.path) {
+                        archiveCoord.build(view: .listView)
+                            .navigationDestination(for: ArchiveView.self) { view in
+                                archiveCoord.build(view: view)
+                            }
+                            .sheet(item: $archiveCoord.sheet) { sheet in
+                                archiveCoord.buildSheet(sheet: sheet)
+                            }
+                            .fullScreenCover(item: $archiveCoord.fullScreenCover) { cover in
+                                archiveCoord.buildFullScreenCover(cover: cover)
+                            }
+                    }
+                    .environment(archiveCoord)
                 }
                 
                 Tab("Map View", systemImage: "map.fill", value: .map) {

--- a/AGAMI/Sources/Presentation/View/HomeView.swift
+++ b/AGAMI/Sources/Presentation/View/HomeView.swift
@@ -48,14 +48,26 @@ struct HomeView: View {
                     }
                     .tag(TabSelection.music)
 
-                ShazamHomeView()
-                    .tabItem {
-                        VStack {
-                            Text("Archive")
-                            Image(systemName: "archivebox.fill")
+                NavigationStack(path: $archiveCoord.path) {
+                    archiveCoord.build(view: .listView)
+                        .navigationDestination(for: ArchiveView.self) { view in
+                            archiveCoord.build(view: view)
                         }
+                        .sheet(item: $archiveCoord.sheet) { sheet in
+                            archiveCoord.buildSheet(sheet: sheet)
+                        }
+                        .fullScreenCover(item: $archiveCoord.fullScreenCover) { cover in
+                            archiveCoord.buildFullScreenCover(cover: cover)
+                        }
+                }
+                .environment(archiveCoord)
+                .tabItem {
+                    VStack {
+                        Text("Archive")
+                        Image(systemName: "archivebox.fill")
                     }
-                    .tag(TabSelection.shazam)
+                }
+                .tag(TabSelection.shazam)
                 
                 MapView()
                     .tabItem {

--- a/AGAMI/Sources/Presentation/ViewModel/Archive/ArchiveListViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Archive/ArchiveListViewModel.swift
@@ -9,10 +9,12 @@ import Foundation
 
 @Observable
 final class ArchiveListViewModel {
-    let dummyURL: URL? = .init(string: "https://dummyimage.com/400x400/000/fff")
+    let dummyURL: URL? = .init(string: "https://dummyimage.com/400x400/fff/000")
 
     var selectedCard: Int?
     var currentId: Int?
+
+    var searchText: String = ""
 
     func isCurrent(_ index: Int) -> Bool {
         currentId == index
@@ -27,6 +29,6 @@ final class ArchiveListViewModel {
     }
 
     func getCardsPadding(_ index: Int, size: CGSize) -> CGFloat {
-        currentId == index ? size.width * 0.4 : -size.width * 0.3
+        currentId == index ? size.width * 0.7 : 0
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/Archive/ArchiveListViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Archive/ArchiveListViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  ArchiveListViewModel.swift
+//  AGAMI
+//
+//  Created by 박현수 on 10/14/24.
+//
+
+import Foundation
+
+@Observable
+final class ArchiveListViewModel {
+    let dummyURL: URL? = .init(string: "https://dummyimage.com/400x400/000/fff")
+
+    var selectedCard: Int?
+    var currentId: Int?
+
+    func isCurrent(_ index: Int) -> Bool {
+        currentId == index
+    }
+
+    func setSelectedCard(_ index: Int?) {
+        selectedCard = index
+    }
+
+    func setCurrentId(_ index: Int?) {
+        currentId = index
+    }
+
+    func getCardsPadding(_ index: Int, size: CGSize) -> CGFloat {
+        currentId == index ? size.width * 0.4 : -size.width * 0.3
+    }
+}

--- a/AGAMI/Sources/Presentation/ViewModel/Archive/ArchivePlaylistViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Archive/ArchivePlaylistViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  ArchivePlaylistViewModel.swift
+//  AGAMI
+//
+//  Created by 박현수 on 10/15/24.
+//
+
+import Foundation
+
+@Observable
+final class ArchivePlaylistViewModel {
+    struct DummySongModel: Identifiable {
+        let id = UUID()
+        let imageURL: URL? = .init(string: "https://dummyimage.com/400x400/000/fff")
+        let title: String = "Under The Influence"
+        let artist: String = "Chris Brown"
+    }
+
+    let dummyURL: URL? = .init(string: "https://dummyimage.com/400x400/fff/000")
+
+    var playlistTitle: String = "플레이리스트 타이틀"
+    var playlistDescription: String = "몽마르트 언덕에선 아코디언 연주자가 부드럽고 감미로운 멜로디를 연주하고 있고, 강변을 걷다 보니 어디선가 자주 들리던 샹송이 바람을 타고 내 귀에 스며들었다."
+
+    var dummyPlaylist: [DummySongModel] = Array(repeating: .init(), count: 10)
+
+    func deleteMusic(idxSet: IndexSet) {
+        for idx in idxSet {
+            dummyPlaylist.remove(at: idx)
+        }
+    }
+
+    func moveMusic(from source: IndexSet, to destination: Int) {
+        dummyPlaylist.move(fromOffsets: source, toOffset: destination)
+    }
+}

--- a/AGAMI/Sources/Presentation/ViewModel/Archive/ArchivePlaylistViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Archive/ArchivePlaylistViewModel.swift
@@ -23,9 +23,9 @@ final class ArchivePlaylistViewModel {
 
     var dummyPlaylist: [DummySongModel] = Array(repeating: .init(), count: 10)
 
-    func deleteMusic(idxSet: IndexSet) {
-        for idx in idxSet {
-            dummyPlaylist.remove(at: idx)
+    func deleteMusic(indexSet: IndexSet) {
+        for index in indexSet {
+            dummyPlaylist.remove(at: index)
         }
     }
 


### PR DESCRIPTION
## ✅ Description
- Archive 탭 UI 구현

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- ### 코디네이터
    - 현재 3개의 탭으로 나누어져 있어, 탭별로 별도의 코디네이터를 구축해야 할 것 같습니다
    - 확장을 고려해 일단 만들어 두긴 했는데, 현재 규모에서는 불필요해 보이긴 합니다
    - 어떻게 하면 좋을지 이야기해보아요 ~~~
- ### Wallet UI
    - `currentId`로 올라온 셀에 bottom 패딩을 주는 방법으로 현재 셀 타겟팅을 하고 있습니다
        - 아래 -> 위 스크롤 시 끊김
        - 스크롤 애니메이션이 완전히 끝나기 전 셀을 터치하면 스크롤 제스처로 인식
        - `selectedCard = nil`에 `withAnimation` 걸면 `matchedGeometryEffect` 애니메이션, 셀 위치 버그가 생깁니다
    - 이러한 버그들이 있어 추후 전면적인 수정이 필요할 것 같습니다.. 머리 박아봤는데 잘 안되네요
    - ❗️Update
        - Wallet UI 카드들끼리 겹쳐지지 않는 형태로 수정된다고 합니다. 디자인 수정 완료되면 맞춰서 수정할게요
- ### ❗️List inside ScrollView
    - 현재 디자인이 `ScrollView` 안에 `List`가 네스팅 되어있는 형태입니다.
        - 스크롤뷰 안에 리스트를 네스팅하면 스크롤 이벤트를 관리하는 뷰가 중복되기 때문에 리스트가 보이지 않습니다
        - 일단 `.scaleToFit()`, `.scrollDisabled(true)`로 리스트가 뷰에 올라오도록 임시방편으로 막아 두었으나 리스트 스크롤 이벤트가 꺼져 있기 때문에 화면 영역 이상의 데이터가 있을 경우 리스트 내부에서 탐색이 불가능합니다
        - 현재 해당 이슈 디자인에 공유해 두었고, 추후 플레이리스트가 별도의 뷰로 분리될 예정이라고 합니다

## 📸 Simulator
https://github.com/user-attachments/assets/0395eaf3-e5c1-4073-ae60-8daec7cd33a9

## 💡 Issue
- Resolved: #9 
