### PR TITLE
[#20] FirebaseAuth 연동

### DIFF
--- a/AGAMI/Resources/Info/GoogleService-Info.plist
+++ b/AGAMI/Resources/Info/GoogleService-Info.plist
@@ -3,17 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyCQa09V1EvYOFvJD2YX_lHZS9V5dZ7eD64</string>
+	<string>AIzaSyAWIaZ8eNzGR0BeKwGyeXETz_9s0uCnJlU</string>
 	<key>GCM_SENDER_ID</key>
-	<string>1053499682046</string>
+	<string>322628630614</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>io.tuist.AGAMI</string>
 	<key>PROJECT_ID</key>
-	<string>agami-macc</string>
+	<string>agami-95d9f</string>
 	<key>STORAGE_BUCKET</key>
-	<string>agami-macc.appspot.com</string>
+	<string>agami-95d9f.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:1053499682046:ios:ea45a38327c337d3d389af</string>
+	<string>1:322628630614:ios:7f56c730f12e1f2dbf63f7</string>
 </dict>
 </plist>

--- a/AGAMI/Sources/Extensions/View+.swift
+++ b/AGAMI/Sources/Extensions/View+.swift
@@ -19,5 +19,5 @@ extension View {
         } else {
             self.toolbar(visibility, for: bar)
         }
-    }g
+    }
 }

--- a/AGAMI/Sources/Extensions/View+.swift
+++ b/AGAMI/Sources/Extensions/View+.swift
@@ -19,5 +19,5 @@ extension View {
         } else {
             self.toolbar(visibility, for: bar)
         }
-    }
+    }g
 }

--- a/AGAMI/Sources/Presentation/View/HomeView.swift
+++ b/AGAMI/Sources/Presentation/View/HomeView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import FirebaseAuth
 
 struct HomeView: View {
     @State private var selectedTab: TabSelection = .search

--- a/AGAMI/Sources/Presentation/View/SignInView.swift
+++ b/AGAMI/Sources/Presentation/View/SignInView.swift
@@ -18,7 +18,7 @@ struct SignInView: View {
             Spacer()
             
             SignInWithAppleButton(.continue) { request in
-                viewModel.SignInRequest(request: request)
+                viewModel.signInRequest(request: request)
             } onCompletion: { result in
                 switch result {
                 case .success(let authorization):

--- a/AGAMI/Sources/Presentation/View/SignInView.swift
+++ b/AGAMI/Sources/Presentation/View/SignInView.swift
@@ -7,16 +7,18 @@
 
 import SwiftUI
 import AuthenticationServices
+import FirebaseAuth
+import CryptoKit
 
 struct SignInView: View {
-    @State private var viewModel: SignInViewModel = SignInViewModel()
-
+        @State private var viewModel: SignInViewModel = SignInViewModel()
+    
     var body: some View {
         VStack {
             Spacer()
-
+            
             SignInWithAppleButton(.continue) { request in
-                request.requestedScopes = [.fullName, .email]
+                viewModel.SignInRequest(request: request)
             } onCompletion: { result in
                 switch result {
                 case .success(let authorization):

--- a/AGAMI/Sources/Presentation/View/UploadImageTestView.swift
+++ b/AGAMI/Sources/Presentation/View/UploadImageTestView.swift
@@ -16,7 +16,7 @@ struct UploadImageTestView: View {
     @State private var uploadResultMessage: String = ""
     
     private let userID = "123456"
-    private let playlistID = "08AEDA20-460A-403C-A04A-A411F6109DFC"
+    private let playlistID = "C7B36178-B1BC-4B90-B08E-69B4130C4376"
     
     var body: some View {
         VStack {

--- a/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import AuthenticationServices
 
 @Observable
-class SignInViewModel {
+final class SignInViewModel {
         
     private let firebaseAuthService = FirebaseAuthService()
 
@@ -20,7 +20,6 @@ class SignInViewModel {
             request.nonce = firebaseAuthService.sha256(nonce)
         }
     }
-    
     
     func handleSuccessfulLogin(with authorization: ASAuthorization) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {

--- a/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
@@ -10,28 +10,23 @@ import AuthenticationServices
 
 @Observable
 class SignInViewModel {
-    
-    var currentNonce: String?
-    
+        
     private let firebaseAuthService = FirebaseAuthService()
 
     func signInRequest(request: ASAuthorizationAppleIDRequest) {
-        generateNonce()
+        firebaseAuthService.generateNonce()
         request.requestedScopes = [.fullName, .email]
-        if let nonce = currentNonce {
+        if let nonce = firebaseAuthService.currentNonce {
             request.nonce = firebaseAuthService.sha256(nonce)
         }
     }
     
-    func generateNonce() {
-        currentNonce = firebaseAuthService.randomNonceString()
-    }
     
     func handleSuccessfulLogin(with authorization: ASAuthorization) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             let idToken = appleIDCredential.identityToken
             
-            guard let nonce = currentNonce else {
+            guard let nonce = firebaseAuthService.currentNonce else {
                 dump("Nonce가 존재하지 않습니다.")
                 return
             }

--- a/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
@@ -9,22 +9,60 @@ import Foundation
 import AuthenticationServices
 
 @Observable
-final class SignInViewModel {
+class SignInViewModel {
+    
+    var currentNonce: String?
+    
+    private let firebaseAuthService = FirebaseAuthService()
+
+    func SignInRequest(request: ASAuthorizationAppleIDRequest) {
+        generateNonce()
+        request.requestedScopes = [.fullName, .email]
+        if let nonce = currentNonce {
+            request.nonce = firebaseAuthService.sha256(nonce)
+        }
+    }
+    
+    func generateNonce() {
+        currentNonce = firebaseAuthService.randomNonceString()
+    }
+    
     func handleSuccessfulLogin(with authorization: ASAuthorization) {
-        if let userCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            dump(userCredential.user)
-            if userCredential.authorizedScopes.contains(.fullName) {
-                dump(userCredential.fullName?.givenName ?? "No given name")
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            let idToken = appleIDCredential.identityToken
+            
+            guard let nonce = currentNonce else {
+                dump("Nonce가 존재하지 않습니다.")
+                return
+            }
+            
+            guard let idTokenString = idToken.flatMap({ String(data: $0, encoding: .utf8) }) else {
+                dump("ID 토큰을 가져오는 데 실패했습니다.")
+                return
+            }
+            
+            firebaseAuthService.signInWithFirebase(idTokenString: idTokenString, nonce: nonce) { result in
+                switch result {
+                case .success(let uid):
+                    dump("Firebase에 사용자 로그인 완료: \(uid)")
+                    UserDefaults.standard.set(true, forKey: "isSignedIn")
+                case .failure(let error):
+                    dump("Firebase 로그인 에러: \(error.localizedDescription)")
+                    self.handleLoginError(with: error)
+                }
             }
 
-            if userCredential.authorizedScopes.contains(.email) {
-                dump(userCredential.email ?? "No email")
+            if appleIDCredential.authorizedScopes.contains(.fullName) {
+                dump(appleIDCredential.fullName?.givenName ?? "이름 없음")
+            }
+            
+            if appleIDCredential.authorizedScopes.contains(.email) {
+                dump(appleIDCredential.email ?? "이메일 없음")
             }
         }
-        UserDefaults.standard.set(true, forKey: "isSignedIn")
     }
-
+    
     func handleLoginError(with error: Error) {
-        dump("Could not authenticate: \(error.localizedDescription)")
+        dump("인증 실패: \(error.localizedDescription)")
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/SignInViewModel.swift
@@ -15,7 +15,7 @@ class SignInViewModel {
     
     private let firebaseAuthService = FirebaseAuthService()
 
-    func SignInRequest(request: ASAuthorizationAppleIDRequest) {
+    func signInRequest(request: ASAuthorizationAppleIDRequest) {
         generateNonce()
         request.requestedScopes = [.fullName, .email]
         if let nonce = currentNonce {

--- a/AGAMI/Sources/Service/FirebaseAuthService.swift
+++ b/AGAMI/Sources/Service/FirebaseAuthService.swift
@@ -11,7 +11,13 @@ import FirebaseAuth
 
 final class FirebaseAuthService {
     
-    func randomNonceString(length: Int = 32) -> String {
+    var currentNonce: String?
+
+    func generateNonce() {
+        currentNonce = randomNonceString()
+    }
+    
+    private func randomNonceString(length: Int = 32) -> String {
         precondition(length > 0)
         let charset: [Character] =
         Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")

--- a/AGAMI/Sources/Service/FirebaseAuthService.swift
+++ b/AGAMI/Sources/Service/FirebaseAuthService.swift
@@ -1,0 +1,79 @@
+//
+//  FirebaseAuthService.swift
+//  AGAMI
+//
+//  Created by taehun on 10/18/24.
+//
+
+import Foundation
+import CryptoKit
+import FirebaseAuth
+
+final class FirebaseAuthService {
+    
+    func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0..<16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                
+                if errorCode != errSecSuccess {
+                    fatalError("Nonce 생성 실패. OSStatus \(errorCode)")
+                }
+                return random
+            }
+            
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+                
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+    
+    func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
+        return hashString
+    }
+    
+    func signInWithFirebase(idTokenString: String, nonce: String, completion: @escaping (Result<String, Error>) -> Void) {
+        let credential = OAuthProvider.credential(
+            withProviderID: "apple.com",
+            idToken: idTokenString,
+            rawNonce: nonce
+        )
+        
+        Auth.auth().signIn(with: credential) { authResult, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            if let uid = authResult?.user.uid {
+                completion(.success(uid))
+            }
+        }
+    }
+    
+    func signOut(completion: @escaping (Result<Void, Error>) -> Void) {
+           do {
+               try Auth.auth().signOut()
+               completion(.success(()))
+           } catch let signOutError as NSError {
+               completion(.failure(signOutError))
+           }
+       }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -2,6 +2,7 @@ import ProjectDescription
 
 let project = Project(
     name: "AGAMI",
+    settings: Settings.settings(base: ["OTHER_LDFLAGS":["-all_load -Objc"]]),
     targets: [
         .target(
             name: "AGAMI",

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "87dd288fc792bf9751e522e171a47df5b783b0b8",
-        "version" : "11.1.0"
+        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
+        "version" : "10.19.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "f909f901bfba9e27e4e9da83242a4915d6dd64bb",
-        "version" : "11.3.0"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "93406fd21b85e66e2d6dbf50b472161fd75c3f1f",
-        "version" : "11.3.0"
+        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
+        "version" : "10.28.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
-        "version" : "8.0.2"
+        "revision" : "57a1d307f42df690fdef2637f3e5b776da02aad6",
+        "version" : "7.13.3"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
-        "version" : "1.65.1"
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Add your own dependencies here:
         // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
         // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.3.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.22.0")
     ],
     targets: [
             .target(


### PR DESCRIPTION
## ✅ Description
- auth 연동하는 과정에서 앱을 빌드를 하면 성공하지만 FIrebase Auth를 통해 로그인을 시도하게 되면 확률적으로 앱이 터지는 상황이 하였고, 다음과 같은 로그가 출력되었습니다. 
`Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '+[NSData gul_dataByGzippingData:error:]: unrecognized selector sent to class 0x1fd063828'`

정확한 원인은 아니지만 다음과 같이 판단하고 해결해봤습니다.

Firebase iOS SDK가 Objective-C로 구현되어 있고, objc 카테고리에서는 기본적으로 동적 로딩을 하게 됩니다. objc안에 있는 클래스나 메소드가 
처음으로 호출되면 심볼을 찾고 메모리에 로드를 하게 됩니다. 

로드 후 호출을 하게 되면 문제가 없지만, 다음과 같은 상황에서는 문제가 발생할 수 있습니다.

1. 클래스는 호출하지 않고, 클래스 안에 있는 메소드를 호출
2. 클래스가 호출되지 않으면 메소드는 로드 X
3. 따라서 메소드 호출 시 unrecognized selector 에러 발생

이를 해결하기 위해 Project.swift에
<img width="620" alt="image" src="https://github.com/user-attachments/assets/7a62c5e0-74ca-452e-9205-4400f6a92efb">
를 추가하였습니다.

'Settings.settings(base: ["OTHER_LDFLAGS":["-all_load -Objc"]])'

'-Objc' 플래그와 '-all_load' 플래그를 추가하게 되면 포함된 라이브러리 내에서 objc 카테고리의 모든 클래스와 메소드를 빌드 시 로드를 강제하게 됩니다. 이는 빌드 타임에 영향을 줄 수 있지만 미리 로드를 하게 되어 메소드가 호출이 되어도 문제가 발생하지 않게 됩니다.

- 위 에러 해결 후 로그인, 로그아웃을 위한 viewModel과 service 구현하였습니다.

- viewModel에서 @escaping을 사용하는 함수를 swift concurrency를 활용해 구현하려고 하다가 또 다른 에러가 발생할 것 같아서 일단 보류해 뒀습니다. 내부 쇼케이스가 끝나고 여유가 생긴다면 시도해보도록 하겠습니다.
![image](https://github.com/user-attachments/assets/37c84138-bbbd-4f49-a305-af0c8c750054)

- firebase 오류 잡느라 새롭게 firebase project 팠습니다. 다시 초대하도록 하겠습니다.

## ⭐️ PR Point
- 위의 에러 해결 방안이 잘못되었다고 생각이 든다면 피드백 부탁드립니다.
- viewModel과 service를 분리함에 있어서 수정 사항이 있다면 피드백 부탁드립니다.

## 📸 Simulator

https://github.com/user-attachments/assets/147d53c2-f031-452b-a036-d359ac2f5a3a

![image](https://github.com/user-attachments/assets/fd1aa7ca-c909-4dfb-89cb-b0a71685b3cb)


## 💡 Issue
- Resolved: #20 
