### PR TITLE
[#50] 플레이리스트 스포티파이로 내보내기 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ Derived/
 
 ### Tuist managed dependencies ###
 Tuist/.build
+
+SpotifyAPIKey.swift

--- a/AGAMI/Sources/Service/Spotify/SpotifyService.swift
+++ b/AGAMI/Sources/Service/Spotify/SpotifyService.swift
@@ -1,0 +1,279 @@
+//
+//  SpotifyService.swift
+//  AGAMI
+//
+//  Created by Seoyeon Choi on 10/24/24.
+//
+
+import UIKit
+
+import Combine
+import SpotifyWebAPI
+import KeychainAccess
+
+@Observable
+public final class SpotifyService {
+    public static let shared = SpotifyService()
+    private let spotifyAPI = SpotifyAPI(authorizationManager:
+                                            AuthorizationCodeFlowManager(clientId: SpotifyAPIKey.clientId,
+                                                                         clientSecret: SpotifyAPIKey.clientSecret))
+    private let loginCallbackURL = URL(string: SpotifyAPIKey.redirectUri)!
+    private let authorizationManagerKey = "authorizationManagerKey"
+    private var authorizationState = String.randomURLSafe(length: 128)
+    private let keychain = Keychain(service: "com.agami.plake")
+    
+    private var isAuthorized = false
+    private var isRetrievingTokens = false
+    var currentUser: SpotifyUser?
+    
+    private var cancellables: Set<AnyCancellable> = []
+    
+    private init() {
+        self.spotifyAPI.apiRequestLogger.logLevel = .trace
+        
+        self.spotifyAPI.authorizationManagerDidChange
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: authorizationManagerDidChange)
+            .store(in: &cancellables)
+        
+        self.spotifyAPI.authorizationManagerDidDeauthorize
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: authorizationManagerDidDeauthorize)
+            .store(in: &cancellables)
+        
+        getAuthorizationManager()
+        
+    }
+    
+    private func getAuthorizationManager() {
+        if let authManagerData = keychain[data: self.authorizationManagerKey] {
+            
+            do {
+                // Try to decode the data.
+                let authorizationManager = try JSONDecoder().decode(
+                    AuthorizationCodeFlowManager.self,
+                    from: authManagerData
+                )
+                print("found authorization information in keychain")
+                
+                self.spotifyAPI.authorizationManager = authorizationManager
+                
+            } catch {
+                print("could not decode authorizationManager from data:\n\(error)")
+            }
+        } else {
+            print("did NOT find authorization information in keychain")
+        }
+    }
+    
+    private func authorize() {
+        print(self.loginCallbackURL)
+        let url = self.spotifyAPI.authorizationManager.makeAuthorizationURL(
+            redirectURI: self.loginCallbackURL,
+            showDialog: true,
+            state: self.authorizationState,
+            scopes: [
+                .playlistModifyPrivate,
+                .playlistModifyPublic
+            ]
+        )!
+        UIApplication.shared.open(url)
+        
+    }
+    
+    private func authorizationManagerDidChange() {
+        
+        self.isAuthorized = self.spotifyAPI.authorizationManager.isAuthorized()
+        
+        print(
+            "Spotify.authorizationManagerDidChange: isAuthorized:",
+            self.isAuthorized
+        )
+        
+        self.retrieveCurrentUser()
+        
+        do {
+            let authManagerData = try JSONEncoder().encode(
+                self.spotifyAPI.authorizationManager
+            )
+            
+            self.keychain[data: self.authorizationManagerKey] = authManagerData
+            print("did save authorization manager to keychain")
+            
+        } catch {
+            print(
+                "couldn't encode authorizationManager for storage " +
+                "in keychain:\n\(error)"
+            )
+        }
+        
+    }
+    
+    private func authorizationManagerDidDeauthorize() {
+        
+        self.isAuthorized = false
+        
+        self.currentUser = nil
+        
+        do {
+            try self.keychain.remove(self.authorizationManagerKey)
+            print("did remove authorization manager from keychain")
+            
+        } catch {
+            print(
+                "couldn't remove authorization manager " +
+                "from keychain: \(error)"
+            )
+        }
+    }
+    
+    private func retrieveCurrentUser(onlyIfNil: Bool = true) {
+        
+        if onlyIfNil && self.currentUser != nil {
+            return
+        }
+        
+        guard self.isAuthorized else { return }
+        
+        self.spotifyAPI.currentUserProfile()
+            .receive(on: RunLoop.main)
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        print("couldn't retrieve current user: \(error)")
+                    }
+                },
+                receiveValue: { user in
+                    self.currentUser = user
+                }
+            )
+            .store(in: &cancellables)
+    }
+    
+    public func handleURL(_ url: URL) {
+        guard url.scheme == self.loginCallbackURL.scheme else {
+            print("not handling URL: unexpected scheme: '\(url)'")
+            return
+        }
+        
+        print("received redirect from Spotify: '\(url)'")
+        
+        self.isRetrievingTokens = true
+        
+        self.spotifyAPI.authorizationManager.requestAccessAndRefreshTokens(
+            redirectURIWithQuery: url,
+            state: self.authorizationState
+        )
+        .receive(on: RunLoop.main)
+        .sink(receiveCompletion: { completion in
+            self.isRetrievingTokens = false
+            
+            if case .failure(let error) = completion {
+                print("couldn't retrieve access and refresh tokens:\n\(error)")
+                if let authError = error as? SpotifyAuthorizationError,
+                   authError.accessWasDenied {
+                }
+            }
+        })
+        .store(in: &cancellables)
+        
+        self.authorizationState = String.randomURLSafe(length: 128)
+        authorizationManagerDidChange()
+        
+    }
+    
+    public func addPlayList(name: String,
+                            musicList: [(String, String?)],
+                            venue: String?,
+                            _ completionHandeler: ()->Void) {
+        if currentUser == nil {
+            authorize()
+        } else {
+            performPlaylistCreation(name: name, musicList: musicList, venue: venue)
+            completionHandeler()
+        }
+    }
+    
+    private func performPlaylistCreation(name: String,
+                                         musicList: [(String, String?)],
+                                         venue: String?) {
+        var trackUris: [String] = []
+        var playlistUri: String = ""
+        
+        func searchTracks() -> AnyPublisher<Void, Error> {
+            
+            return Publishers.Sequence(sequence: musicList)
+                .flatMap(maxPublishers: .max(1)) { song -> AnyPublisher<String?, Never> in
+                    let query = "\(song.1 ?? "") \(song.0)"
+                    print("@LOG query: \(query)")
+                    let categories: [IDCategory] = [.artist, .track]
+                    
+                    return self.spotifyAPI.search(query: query, categories: categories, limit: 1)
+                        .map { searchResult in
+                            print("@LOG searchResult \(searchResult.tracks?.items.first?.name ?? "nil")")
+                            return searchResult.tracks?.items.first?.uri
+                        }
+                        .replaceError(with: nil)
+                        .eraseToAnyPublisher()
+                }
+                .compactMap { $0 }
+                .collect()
+                .map { nonDuplicateTrackUris in
+                    trackUris = nonDuplicateTrackUris
+                }
+                .eraseToAnyPublisher()
+        }
+        
+        func createPlaylist() -> AnyPublisher<Void, Error> {
+            guard let userURI: SpotifyURIConvertible = self.currentUser?.uri else {
+                return Fail(error: ErrorType.userNotFound).eraseToAnyPublisher()
+            }
+            
+            let playlistDetails = PlaylistDetails(name: "\(name) @ \(DateFormatter.spotifyAlbumLong.string(from: Date()))",
+                                                  isPublic: false,
+                                                  isCollaborative: false,
+                                                  description: "Plake에서 생성된 플레이리스트 입니다.")
+            
+            return self.spotifyAPI.createPlaylist(for: userURI, playlistDetails)
+                .map { playlist in
+                    print("Playlist created: \(playlist)")
+                    playlistUri = playlist.uri
+                }
+                .eraseToAnyPublisher()
+        }
+        
+        func addTracks() -> AnyPublisher<Void, Error> {
+            guard !trackUris.isEmpty else {
+                return Fail(error: ErrorType.noTracksFound).eraseToAnyPublisher()
+            }
+            
+            let uris: [SpotifyURIConvertible] = trackUris
+            
+            return self.spotifyAPI.addToPlaylist(playlistUri, uris: uris)
+                .map { result in
+                    print("Items added successfully. Result: \(result)")
+                }
+                .eraseToAnyPublisher()
+        }
+        
+        searchTracks()
+            .flatMap { _ in createPlaylist() }
+            .flatMap { _ in addTracks() }
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    print("Playlist creation completed successfully.")
+                case .failure(let error):
+                    print("Error: \(error)")
+                }
+            }, receiveValue: {})
+            .store(in: &cancellables)
+    }
+    
+    private enum ErrorType: Error {
+        case trackNotFound
+        case userNotFound
+        case noTracksFound
+    }
+}
+

--- a/AGAMI/Sources/Service/Spotify/SpotifyService.swift
+++ b/AGAMI/Sources/Service/Spotify/SpotifyService.swift
@@ -12,8 +12,8 @@ import SpotifyWebAPI
 import KeychainAccess
 
 @Observable
-public final class SpotifyService {
-    public static let shared = SpotifyService()
+final class SpotifyService {
+    static let shared = SpotifyService()
     private let spotifyAPI = SpotifyAPI(authorizationManager:
                                             AuthorizationCodeFlowManager(clientId: SpotifyAPIKey.clientId,
                                                                          clientSecret: SpotifyAPIKey.clientSecret))
@@ -181,10 +181,10 @@ public final class SpotifyService {
         authorizationManagerDidChange()
     }
     
-    public func addPlayList(name: String,
-                            musicList: [(String, String?)],
-                            venue: String?,
-                            _ completionHandler: () -> Void) {
+    func addPlayList(name: String,
+                     musicList: [(String, String?)],
+                     venue: String?,
+                     _ completionHandler: () -> Void) {
         if currentUser == nil {
             authorize()
         } else {

--- a/AGAMI/Sources/Service/Spotify/SpotifyService.swift
+++ b/AGAMI/Sources/Service/Spotify/SpotifyService.swift
@@ -188,18 +188,20 @@ final class SpotifyService {
     func addPlayList(name: String,
                      musicList: [(String, String?)],
                      venue: String?,
-                     _ completionHandler: () -> Void) {
+                     _ completionHandler: @escaping (String?) -> Void) {
         if currentUser == nil {
             authorize()
         } else {
-            performPlaylistCreation(name: name, musicList: musicList, venue: venue)
-            completionHandler()
+            performPlaylistCreation(name: name, musicList: musicList, venue: venue) { playlistUri in
+                completionHandler(playlistUri)
+            }
         }
     }
     
     private func performPlaylistCreation(name: String,
                                          musicList: [(String, String?)],
-                                         venue: String?) {
+                                         venue: String?,
+                                         _ completionHandler: @escaping (String?) -> Void) {
         var trackUris: [String] = []
         var playlistUri: String = ""
         
@@ -266,8 +268,10 @@ final class SpotifyService {
                 switch completion {
                 case .finished:
                     print("Playlist creation completed successfully.")
+                    completionHandler(playlistUri)
                 case .failure(let error):
                     print("Error: \(error)")
+                    completionHandler(nil)
                 }
             }, receiveValue: {})
             .store(in: &cancellables)

--- a/AGAMI/Sources/Service/Spotify/SpotifyService.swift
+++ b/AGAMI/Sources/Service/Spotify/SpotifyService.swift
@@ -14,9 +14,13 @@ import KeychainAccess
 @Observable
 final class SpotifyService {
     static let shared = SpotifyService()
-    private let spotifyAPI = SpotifyAPI(authorizationManager:
-                                            AuthorizationCodeFlowManager(clientId: SpotifyAPIKey.clientId,
-                                                                         clientSecret: SpotifyAPIKey.clientSecret))
+    private let spotifyAPI = SpotifyAPI(
+        authorizationManager:
+            AuthorizationCodeFlowManager(
+                clientId: SpotifyAPIKey.clientId,
+                clientSecret: SpotifyAPIKey.clientSecret
+            )
+    )
     private let loginCallbackURL: URL
     private let authorizationManagerKey = "authorizationManagerKey"
     private var authorizationState = String.randomURLSafe(length: 128)

--- a/AGAMI/Sources/Service/Spotify/SpotifyService.swift
+++ b/AGAMI/Sources/Service/Spotify/SpotifyService.swift
@@ -17,7 +17,7 @@ public final class SpotifyService {
     private let spotifyAPI = SpotifyAPI(authorizationManager:
                                             AuthorizationCodeFlowManager(clientId: SpotifyAPIKey.clientId,
                                                                          clientSecret: SpotifyAPIKey.clientSecret))
-    private let loginCallbackURL = URL(string: SpotifyAPIKey.redirectUri)!
+    private let loginCallbackURL = URL(string: SpotifyAPIKey.redirectURL)!
     private let authorizationManagerKey = "authorizationManagerKey"
     private var authorizationState = String.randomURLSafe(length: 128)
     private let keychain = Keychain(service: "com.agami.plake")
@@ -185,7 +185,7 @@ public final class SpotifyService {
     public func addPlayList(name: String,
                             musicList: [(String, String?)],
                             venue: String?,
-                            _ completionHandeler: ()->Void) {
+                            _ completionHandeler: () -> Void) {
         if currentUser == nil {
             authorize()
         } else {

--- a/Project.swift
+++ b/Project.swift
@@ -48,25 +48,12 @@ let project = Project(
                                 "UIInterfaceOrientationPortrait",
                                 "UIInterfaceOrientationPortraitUpsideDown"
                             ],
-                            "UIAppFonts": .array(
-                                fonts
-                                    .map {
-                                        .string(
-                                            $0
-                                        )
-                                    }),
-                            "LSApplicationQueriesSchemes": .array(
-                                ["spotify"]
-                            ),
-                            "CFBundleURLTypes": .array(
-                                [.dictionary(
-                                    [
-                                        "CFBundleURLSchemes" : .array(
-                                            ["plake-agami"]
-                                        ),
-                                        "CFBundleURLName" : .string(
-                                            "com.agami.plake"
-                                        )
+                            "UIAppFonts": .array( fonts .map { .string( $0 ) }),
+                            "LSApplicationQueriesSchemes": .array( ["spotify"] ),
+                            "CFBundleURLTypes": .array([
+                                .dictionary(
+                                    [ "CFBundleURLSchemes" : .array(["plake-agami"]),
+                                      "CFBundleURLName" : .string("com.agami.plake")
                                     ]
                                 )]
                             )

--- a/Project.swift
+++ b/Project.swift
@@ -14,37 +14,64 @@ let fonts = [
 
 let project = Project(
     name: "AGAMI",
-    settings: Settings.settings(base: [
-        "OTHER_LDFLAGS": ["-all_load -Objc"],
-        "ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME": "AccentColor"
-    ]),
+    settings: Settings
+        .settings(
+            base: [
+                "OTHER_LDFLAGS": ["-all_load -Objc"],
+                "ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME": "AccentColor"
+            ]
+        ),
     targets: [
         .target(
             name: "AGAMI",
             destinations: [.iPhone],
             product: .app,
             bundleId: "io.tuist.AGAMI",
-            deploymentTargets: .iOS("17.0"),
-            infoPlist: .extendingDefault(
-                with: [
-                    "UILaunchScreen": [
-                        "UIColorName": "",
-                        "UIImageName": ""
-                    ],
-                    "NSAppleMusicUsageDescription": "플레이리스트 추가를 위해 Apple Music 라이브러리에 접근합니다.",
-                    "NSMicrophoneUsageDescription": "Shazam 음악 인식을 위해 마이크에 접근합니다.",
-                    "NSPhotoLibraryUsageDescription": "플레이리스트 사진 추가를 위해 사진 라이브러리에 접근합니다.",
-                    "NSCameraUsageDescription": "플레이리스트 사진 추가를 위해 카메라에 접근합니다.",
-                    "NSLocationUsageDescription": "근처 장소 탐색을 위해 사용자의 위치 정보에 접근합니다.",
-                    "NSLocationWhenInUseUsageDescription": "근처 장소 탐색을 위해 사용자의 위치 정보에 접근합니다.",
-                    "UISupportedInterfaceOrientations": [
-                        "UIInterfaceOrientationPortrait",
-                        "UIInterfaceOrientationPortraitUpsideDown"
-                    ],
-                    "UIAppFonts": .array(fonts.map { .string($0) }),
-                    "UIUserInterfaceStyle": "Light"
-                ]
-            ),
+            deploymentTargets:
+                    .iOS(
+                        "17.0"
+                    ),
+            infoPlist:
+                    .extendingDefault(
+                        with: [
+                            "UILaunchScreen": [
+                                "UIColorName": "",
+                                "UIImageName": ""
+                            ],
+                            "NSAppleMusicUsageDescription": "플레이리스트 추가를 위해 Apple Music 라이브러리에 접근합니다.",
+                            "NSMicrophoneUsageDescription": "Shazam 음악 인식을 위해 마이크에 접근합니다.",
+                            "NSPhotoLibraryUsageDescription": "플레이리스트 사진 추가를 위해 사진 라이브러리에 접근합니다.",
+                            "NSCameraUsageDescription": "플레이리스트 사진 추가를 위해 카메라에 접근합니다.",
+                            "NSLocationUsageDescription": "근처 장소 탐색을 위해 사용자의 위치 정보에 접근합니다.",
+                            "NSLocationWhenInUseUsageDescription": "근처 장소 탐색을 위해 사용자의 위치 정보에 접근합니다.",
+                            "UISupportedInterfaceOrientations": [
+                                "UIInterfaceOrientationPortrait",
+                                "UIInterfaceOrientationPortraitUpsideDown"
+                            ],
+                            "UIAppFonts": .array(
+                                fonts
+                                    .map {
+                                        .string(
+                                            $0
+                                        )
+                                    }),
+                            "LSApplicationQueriesSchemes": .array(
+                                ["spotify"]
+                            ),
+                            "CFBundleURLTypes": .array(
+                                [.dictionary(
+                                    [
+                                        "CFBundleURLSchemes" : .array(
+                                            ["plake-agami"]
+                                        ),
+                                        "CFBundleURLName" : .string(
+                                            "com.agami.plake"
+                                        )
+                                    ]
+                                )]
+                            )
+                        ]
+                    ),
             sources: ["AGAMI/Sources/**"],
             resources: ["AGAMI/Resources/**"],
             entitlements: "Entitlements/AGAMI.entitlements",
@@ -52,10 +79,24 @@ let project = Project(
                 .swiftLintShell
             ],
             dependencies: [
-                .external(name: "FirebaseAnalytics"),
-                .external(name: "FirebaseAuth"),
-                .external(name: "FirebaseFirestore"),
-                .external(name: "FirebaseStorage")
+                .external(
+                    name: "FirebaseAnalytics"
+                ),
+                .external(
+                    name: "FirebaseAuth"
+                ),
+                .external(
+                    name: "FirebaseFirestore"
+                ),
+                .external(
+                    name: "FirebaseStorage"
+                ),
+                .external(
+                    name: "SpotifyAPI"
+                ),
+                .external(
+                    name: "KeychainAccess"
+                )
             ]
         ),
         .target(
@@ -66,14 +107,19 @@ let project = Project(
             infoPlist: .default,
             sources: ["AGAMI/Tests/**"],
             resources: [],
-            dependencies: [.target(name: "AGAMI")]
+            dependencies: [.target(
+                name: "AGAMI"
+            )]
         )
     ]
 )
 
 extension TargetScript {
     static let swiftLintShell = TargetScript.pre(
-        path: .relativeToRoot("Scripts/SwiftLintRunScript.sh"),
+        path:
+                .relativeToRoot(
+                    "Scripts/SwiftLintRunScript.sh"
+                ),
         name: "swiftLintShell",
         basedOnDependencyAnalysis: false
     )

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
+      "state" : {
+        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version" : "4.2.2"
+      }
+    },
+    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
@@ -100,12 +109,57 @@
       }
     },
     {
+      "identity" : "opencombine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenCombine/OpenCombine.git",
+      "state" : {
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
+      }
+    },
+    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "regularexpressions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Peter-Schorn/RegularExpressions.git",
+      "state" : {
+        "revision" : "b27140d0bd3a9a1e61f2324f644219be98eb3311",
+        "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "spotifyapi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Peter-Schorn/SpotifyAPI.git",
+      "state" : {
+        "revision" : "daccfb042862bcfd369c7bd1906eddcb801180ee",
+        "version" : "3.0.3"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -15,10 +15,9 @@ import PackageDescription
 let package = Package(
     name: "AGAMI",
     dependencies: [
-        // Add your own dependencies here:
-        // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
-        // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.22.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.22.0"),
+        .package(url: "https://github.com/Peter-Schorn/SpotifyAPI.git", from: "3.0.3"),
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2")
     ],
     targets: [
             .target(
@@ -28,7 +27,9 @@ let package = Package(
                     .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
                     .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
                     .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
-                    .product(name: "FirebaseStorage", package: "firebase-ios-sdk")
+                    .product(name: "FirebaseStorage", package: "firebase-ios-sdk"),
+                    .product(name: "SpotifyAPI", package: "SpotifyAPI"),
+                    .product(name: "KeychainAccess", package: "KeychainAccess")
                 ],
                 path: "AGAMI/Sources"
             ),


### PR DESCRIPTION
## ✅ Description
- 플레이리스트를 스포티파이로 내보내기 기능 구현했습니다. 

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
#### SpotifyAPIKey.swift
tuist에서 `config`파일 추가하는 과정을 겪다가 .. 일단 올려두고 추후에 수정하자! 란 마인드로 
`SpotifyAPIKey.swift` 파일에 api 관련 데이터 저장하고 `gitignore`에 추가하여 깃에서 트래킹되지 않도록 했습니다. 

#### Combine으로 개발되어있습니다 ..
레퍼런스 코드로 SpotifyService를 개발해서 어쩔 수 없이 Combine으로 적용되어있습니다. 
대체로 다 비동기 작업이라 일단 기능 구현은 해두고 추후 Combine 없이 코드 수정해볼게요..!



## 📸 Simulator
<img src="https://github.com/user-attachments/assets/5551ea76-e4f5-4827-8d81-6cdb9ba0db5d" width=300>

## 💡 Issue
- Resolved: #50 
