### PR TITLE
[#73] xcconfig에 Spotify API Key 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ Tuist/.build
 
 SpotifyAPIKey.swift
 AGAMI/Sources/Service/Spotify/SpotifyAPIKey.swift
+
+### Configuration File ###
+*.xcconfig
+

--- a/AGAMI/Sources/App/AGAMIApp.swift
+++ b/AGAMI/Sources/App/AGAMIApp.swift
@@ -14,8 +14,11 @@ struct AGAMIApp: App {
             if isSignedIn {
                 HomeView()
                     .onOpenURL { url in
-                        if url.absoluteString.contains(SpotifyAPIKey.redirectURL) {
-                            SpotifyService.shared.handleURL(url)
+                        if let redirectURL = Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URL") as? String,
+                           let decodedRedirectURL = redirectURL.removingPercentEncoding {
+                            if url.absoluteString.contains(decodedRedirectURL) {
+                                SpotifyService.shared.handleURL(url)
+                            }
                         }
                     }
             } else {

--- a/AGAMI/Sources/Presentation/View/Archive/ArchiveListView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchiveListView.swift
@@ -38,8 +38,11 @@ struct ArchiveListView: View {
             ConfirmationDialogActions(viewModel: viewModel)
         }
         .onOpenURL { url in
-            if url.absoluteString.contains(SpotifyAPIKey.redirectURL) {
-                viewModel.exportingState = .none
+            if let redirectURL = Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URL") as? String,
+               let decodedRedirectURL = redirectURL.removingPercentEncoding {
+                if url.absoluteString.contains(decodedRedirectURL) {
+                    viewModel.exportingState = .none
+                }
             }
         }
     }

--- a/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Archive/ArchivePlaylistView.swift
@@ -46,8 +46,11 @@ struct ArchivePlaylistView: View {
             Text("삭제한 사진은 되돌릴 수 없습니다.")
         }
         .onOpenURL { url in
-            if url.absoluteString.contains(SpotifyAPIKey.redirectURL) {
-                viewModel.exportingState = .none
+            if let redirectURL = Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URL") as? String,
+               let decodedRedirectURL = redirectURL.removingPercentEncoding {
+                if url.absoluteString.contains(decodedRedirectURL) {
+                    viewModel.exportingState = .none
+                }
             }
         }
     }

--- a/AGAMI/Sources/Service/Spotify/SpotifyService.swift
+++ b/AGAMI/Sources/Service/Spotify/SpotifyService.swift
@@ -14,48 +14,53 @@ import KeychainAccess
 @Observable
 final class SpotifyService {
     static let shared = SpotifyService()
-    private let spotifyAPI = SpotifyAPI(
-        authorizationManager:
-            AuthorizationCodeFlowManager(
-                clientId: SpotifyAPIKey.clientId,
-                clientSecret: SpotifyAPIKey.clientSecret
-            )
-    )
+    private let spotifyAPI: SpotifyAPI<AuthorizationCodeFlowManager>
     private let loginCallbackURL: URL
     private let authorizationManagerKey = "authorizationManagerKey"
     private var authorizationState = String.randomURLSafe(length: 128)
     private let keychain = Keychain(service: "com.agami.plake")
-    
+
     private var isAuthorized = false
     private var isRetrievingTokens = false
     var currentUser: SpotifyUser?
-    
+
     private var cancellables: Set<AnyCancellable> = []
-    
+
     private init() {
-        guard let url = URL(string: SpotifyAPIKey.redirectURL) else {
-            fatalError("Invalid redirect URL string.")
+        guard let clientId = Bundle.main.object(forInfoDictionaryKey: "CLIENT_ID") as? String,
+              let clientSecret = Bundle.main.object(forInfoDictionaryKey: "CLIENT_SECRET") as? String,
+              let redirectURL = Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URL") as? String,
+              let decodedRedirectURL = redirectURL.removingPercentEncoding,
+              let url = URL(string: decodedRedirectURL) else {
+            fatalError("Invalid configuration values in Info.plist.")
         }
+
+        self.spotifyAPI = SpotifyAPI(
+            authorizationManager: AuthorizationCodeFlowManager(
+                clientId: clientId,
+                clientSecret: clientSecret
+            )
+        )
         self.loginCallbackURL = url
-        
+
         self.spotifyAPI.apiRequestLogger.logLevel = .trace
-        
+
         self.spotifyAPI.authorizationManagerDidChange
             .receive(on: RunLoop.main)
             .sink(receiveValue: authorizationManagerDidChange)
             .store(in: &cancellables)
-        
+
         self.spotifyAPI.authorizationManagerDidDeauthorize
             .receive(on: RunLoop.main)
             .sink(receiveValue: authorizationManagerDidDeauthorize)
             .store(in: &cancellables)
-        
+
         getAuthorizationManager()
     }
-    
+
     private func getAuthorizationManager() {
         if let authManagerData = keychain[data: self.authorizationManagerKey] {
-            
+
             do {
                 // Try to decode the data.
                 let authorizationManager = try JSONDecoder().decode(
@@ -63,9 +68,9 @@ final class SpotifyService {
                     from: authManagerData
                 )
                 print("found authorization information in keychain")
-                
+
                 self.spotifyAPI.authorizationManager = authorizationManager
-                
+
             } catch {
                 print("could not decode authorizationManager from data:\n\(error)")
             }
@@ -73,7 +78,7 @@ final class SpotifyService {
             print("did NOT find authorization information in keychain")
         }
     }
-    
+
     private func authorize() {
         guard let url = self.spotifyAPI.authorizationManager.makeAuthorizationURL(
             redirectURI: self.loginCallbackURL,
@@ -89,7 +94,7 @@ final class SpotifyService {
         }
         UIApplication.shared.open(url)
     }
-    
+
     private func authorizationManagerDidChange() {
         self.isAuthorized = self.spotifyAPI.authorizationManager.isAuthorized()
 
@@ -115,11 +120,11 @@ final class SpotifyService {
     private func authorizationManagerDidDeauthorize() {
         self.isAuthorized = false
         self.currentUser = nil
-        
+
         do {
             try self.keychain.remove(self.authorizationManagerKey)
             print("did remove authorization manager from keychain")
-            
+
         } catch {
             print(
                 "couldn't remove authorization manager " +
@@ -127,7 +132,7 @@ final class SpotifyService {
             )
         }
     }
-    
+
     private func retrieveCurrentUser(onlyIfNil: Bool = true) {
         if onlyIfNil && self.currentUser != nil {
             return
@@ -147,17 +152,17 @@ final class SpotifyService {
             )
             .store(in: &cancellables)
     }
-    
+
     public func handleURL(_ url: URL) {
         guard url.scheme == self.loginCallbackURL.scheme else {
             print("not handling URL: unexpected scheme: '\(url)'")
             return
         }
-        
+
         print("received redirect from Spotify: '\(url)'")
-        
+
         self.isRetrievingTokens = true
-        
+
         self.spotifyAPI.authorizationManager.requestAccessAndRefreshTokens(
             redirectURIWithQuery: url,
             state: self.authorizationState
@@ -165,7 +170,7 @@ final class SpotifyService {
         .receive(on: RunLoop.main)
         .sink(receiveCompletion: { completion in
             self.isRetrievingTokens = false
-            
+
             if case .failure(let error) = completion {
                 print("couldn't retrieve access and refresh tokens:\n\(error)")
                 if let authError = error as? SpotifyAuthorizationError,
@@ -174,11 +179,11 @@ final class SpotifyService {
             }
         })
         .store(in: &cancellables)
-        
+
         self.authorizationState = String.randomURLSafe(length: 128)
         authorizationManagerDidChange()
     }
-    
+
     func addPlayList(name: String,
                      musicList: [(String, String?)],
                      description: String?,
@@ -191,22 +196,22 @@ final class SpotifyService {
             }
         }
     }
-    
+
     private func performPlaylistCreation(name: String,
                                          musicList: [(String, String?)],
                                          description: String?,
                                          _ completionHandler: @escaping (String?) -> Void) {
         var trackUris: [String] = []
         var playlistUri: String = ""
-        
+
         func searchTracks() -> AnyPublisher<Void, Error> {
-            
+
             return Publishers.Sequence(sequence: musicList)
                 .flatMap(maxPublishers: .max(1)) { song -> AnyPublisher<String?, Never> in
                     let query = "\(song.1 ?? "") \(song.0)"
                     print("@LOG query: \(query)")
                     let categories: [IDCategory] = [.artist, .track]
-                    
+
                     return self.spotifyAPI.search(query: query, categories: categories, limit: 1)
                         .map { searchResult in
                             print("@LOG searchResult \(searchResult.tracks?.items.first?.name ?? "nil")")
@@ -222,12 +227,12 @@ final class SpotifyService {
                 }
                 .eraseToAnyPublisher()
         }
-        
+
         func createPlaylist(description: String?) -> AnyPublisher<Void, Error> {
             guard let userURI: SpotifyURIConvertible = self.currentUser?.uri else {
                 return Fail(error: ErrorType.userNotFound).eraseToAnyPublisher()
             }
-            
+
             let playlistDetails = PlaylistDetails(name: name,
                                                   isPublic: false,
                                                   isCollaborative: false,
@@ -240,21 +245,21 @@ final class SpotifyService {
                 }
                 .eraseToAnyPublisher()
         }
-        
+
         func addTracks() -> AnyPublisher<Void, Error> {
             guard !trackUris.isEmpty else {
                 return Fail(error: ErrorType.noTracksFound).eraseToAnyPublisher()
             }
-            
+
             let uris: [SpotifyURIConvertible] = trackUris
-            
+
             return self.spotifyAPI.addToPlaylist(playlistUri, uris: uris)
                 .map { result in
                     print("Items added successfully. Result: \(result)")
                 }
                 .eraseToAnyPublisher()
         }
-        
+
         searchTracks()
             .flatMap { _ in createPlaylist(description: description) }
             .flatMap { _ in addTracks() }
@@ -270,7 +275,7 @@ final class SpotifyService {
             }, receiveValue: {})
             .store(in: &cancellables)
     }
-    
+
     private enum ErrorType: Error {
         case trackNotFound
         case userNotFound

--- a/Project.swift
+++ b/Project.swift
@@ -19,6 +19,10 @@ let project = Project(
             base: [
                 "OTHER_LDFLAGS": ["-all_load -Objc"],
                 "ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME": "AccentColor"
+            ],
+            configurations: [
+                .debug(name: "Debug", xcconfig: "Configurations/Debug.xcconfig"),
+                .release(name: "Release", xcconfig: "Configurations/Release.xcconfig")
             ]
         ),
     targets: [
@@ -27,10 +31,7 @@ let project = Project(
             destinations: [.iPhone],
             product: .app,
             bundleId: "io.tuist.AGAMI",
-            deploymentTargets:
-                    .iOS(
-                        "17.0"
-                    ),
+            deploymentTargets: .iOS("17.0"),
             infoPlist:
                     .extendingDefault(
                         with: [
@@ -57,7 +58,10 @@ let project = Project(
                                     ]
                                 )]
                             ),
-                            "UIUserInterfaceStyle": "Light"
+                            "UIUserInterfaceStyle": "Light",
+                            "CLIENT_ID": .string("$(CLIENT_ID)"),
+                            "CLIENT_SECRET": .string("$(CLIENT_SECRET)"),
+                            "REDIRECT_URL": .string("$(REDIRECT_URL)")
                         ]
                     ),
             sources: ["AGAMI/Sources/**"],


### PR DESCRIPTION
## ✅ Description
- xcconfig에 Spotify API Key 분리

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- `xcconfig` 이용해 Spotify API Key 분리했습니다
- info.plist에 해당 key들 등록 후 환경 변수를 끌어다 쓰는 형태입니다
- 머지 후 설정 파일 공유 드리겠습니당

## 📸 Simulator
https://github.com/user-attachments/assets/94a71884-040a-4386-b38d-a409ad6c12a2

## 💡 Issue
- Resolved: #73
