### PR TITLE
[#78] SearchWritingView 내 버그 이슈

### DIFF
--- a/AGAMI/Sources/Extensions/UIImage+.swift
+++ b/AGAMI/Sources/Extensions/UIImage+.swift
@@ -16,7 +16,9 @@ extension UIImage {
         )
         let squareRect = CGRect(origin: origin, size: CGSize(width: shortLength, height: shortLength))
         
-        guard let squareImage = self.cgImage?.cropping(to: squareRect) else { return nil }
-        return UIImage(cgImage: squareImage, scale: scale, orientation: imageOrientation)
+        let renderer = UIGraphicsImageRenderer(size: squareRect.size)
+        return renderer.image { _ in
+            self.draw(at: CGPoint(x: -squareRect.origin.x, y: -squareRect.origin.y))
+        }
     }
 }

--- a/AGAMI/Sources/Presentation/View/Components/PlaylistRow.swift
+++ b/AGAMI/Sources/Presentation/View/Components/PlaylistRow.swift
@@ -7,21 +7,22 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct PlaylistRow: View {
     let song: SongModel
 
     var body: some View {
         HStack(spacing: 0) {
-            AsyncImage(url: URL(string: song.albumCoverURL)) { image in
-                image
-                    .resizable()
-                    .frame(width: 60, height: 60)
-
-            } placeholder: {
-                ProgressView()
-                    .frame(width: 60, height: 60)
-            }
-            .padding(.trailing, 20)
+            KFImage(URL(string: song.albumCoverURL))
+                .resizable()
+                .cancelOnDisappear(true)
+                .placeholder({
+                    ProgressView()
+                        .frame(width: 60, height: 60)
+                })
+                .frame(width: 60, height: 60)
+                .padding(.trailing, 20)
 
             VStack(alignment: .leading, spacing: 0) {
                 Text(song.title)

--- a/AGAMI/Sources/Presentation/View/Search/SearchDiggingListModalView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchDiggingListModalView.swift
@@ -47,6 +47,7 @@ struct SearchDiggingListModalView: View {
                         }
                         .onDelete(perform: viewModel.deleteSong)
                         .onMove(perform: viewModel.moveSong)
+                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 2, trailing: 0))
                     }
                     .scrollIndicators(.hidden)
                     .listStyle(InsetGroupedListStyle())

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -26,15 +26,12 @@ struct SearchWritingView: View {
                     .listRowInsets(.zero)
                 
                 PlaylistSongListHeader(viewModel: viewModel)
-                    .padding(.top, 28)
-                    .padding(.horizontal, 24)
+                    .padding(EdgeInsets(top: 28, leading: 24, bottom: 10, trailing: 24))
                     .listRowSeparator(.hidden)
                     .listRowInsets(.zero)
                 
                 PlaylistSongList(viewModel: viewModel)
-                    .padding(.top, 10)
-                    .padding(.horizontal, 8)
-                    .listRowInsets(.zero)
+                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 2, trailing: 0))
                 
                 PlaylistDescriptionTextField(viewModel: viewModel)
                     .padding(.horizontal, 8)
@@ -200,6 +197,7 @@ private struct PlaylistSongList: View {
         }
         .onDelete(perform: viewModel.deleteSong)
         .onMove(perform: viewModel.moveSong)
+        .padding(.horizontal, 8)
     }
 }
 

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -15,13 +15,7 @@ struct SearchWritingView: View {
         ZStack {
             List {
                 PlaylistCoverImageView(viewModel: viewModel)
-                    .onTapGesture {
-                        if viewModel.photoUIImage == nil {
-                            coordinator.push(view: .cameraView(viewModel: viewModel))
-                        } else {
-                            viewModel.showSheet.toggle()
-                        }
-                    }
+                    .highPriorityGesture(imageViewTapGesture())
                     .listRowSeparator(.hidden)
                     .listRowInsets(.zero)
                 
@@ -98,6 +92,16 @@ struct SearchWritingView: View {
         }
         .toolbarRole(.editor)
         .toolbarVisibilityForVersion(.hidden, for: .tabBar)
+    }
+    
+    private func imageViewTapGesture() -> some Gesture {
+        TapGesture().onEnded {
+            if viewModel.photoUIImage == nil {
+                coordinator.push(view: .cameraView(viewModel: viewModel))
+            } else {
+                viewModel.showSheet.toggle()
+            }
+        }
     }
 }
 

--- a/Project.swift
+++ b/Project.swift
@@ -61,7 +61,8 @@ let project = Project(
                             "UIUserInterfaceStyle": "Light",
                             "CLIENT_ID": .string("$(CLIENT_ID)"),
                             "CLIENT_SECRET": .string("$(CLIENT_SECRET)"),
-                            "REDIRECT_URL": .string("$(REDIRECT_URL)")
+                            "REDIRECT_URL": .string("$(REDIRECT_URL)"),
+                            "CFBundleDisplayName": "Plake"
                         ]
                     ),
             sources: ["AGAMI/Sources/**"],


### PR DESCRIPTION
## ✅ Description
- SearchWritingView 내 버그 이슈 해결했습니다. 

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
#### 이미지 정방향 찌그러지는 이슈
기존 UIImage+ 익스텐션 내 cropSquare() 함수에 코드를 추가했습니다. 
```
let renderer = UIGraphicsImageRenderer(size: squareRect.size)
    return renderer.image { _ in
        self.draw(at: CGPoint(x: -squareRect.origin.x, y: -squareRect.origin.y))
    }
```
`UIGraphicsImageRenderer`는 크롭된 이미지를 정사각형 비율로 왜곡 없이 만들어줍니다. 
`CGPoint` 오프셋을 사용하여 이미지의 크롭된 위치를 조정하고, 이로 인해 원하는 정사각형 부분만 잘려나온 이미지가 반환됩니다.

#### `onTapGesture` 중첩 이슈
`SearchWritingView` 내 가장 밖단의 `ZStack`에 `hideKeyboard()` 탭 제스처와 `List` 내 `PlaylistCoverImageView` 에 탭 제스쳐가 있어서 최상위 뷰의 제스처로 인해 사진 탭이 안먹히는 이슈가 있었습니다. 
```
.highPriorityGesture(imageViewTapGesture())

    private func imageViewTapGesture() -> some Gesture {
        TapGesture().onEnded {
            if viewModel.photoUIImage == nil {
                coordinator.push(view: .cameraView(viewModel: viewModel))
            } else {
                viewModel.showSheet.toggle()
            }
        }
    }
```
`PlaylistCoverImageView` 탭 제스처에 들어가는 함수를 따로 private 함수로 빼주었습니다.
그리고 `highPriorityGesture`라는 모디파이어를 활용해서 다른 gesture modifier들보다 높은 우선순위를 가지는 제스처를 뷰에 추가할 수 있게 해주었습니다. 
수박박이 알려줬어요 **나이뜨 수박 !**


#### PlaylistRow Kingfisher 반영
뷰를 오갈때마다 List row 에 있는 이미지들이 계속 리로딩되는 이슈가 있었습니다. (이미지 캐싱이 안됨)
따라서 수박이 넣어준 Kingfisher 서드파티를 활용해 이미지를 가져오고 캐싱까지 할 수 있도록 수정했습니다. 

#### 앱 이름 수정
info.plist에 `CFBundleDisplayName` key를 추가하여 앱 이름을 Plake로 수정했습니다. 

## 📸 Simulator


## 💡 Issue
- Resolved: #78
- 커밋 번호가 64번으로 되어있네요 죄송함다 확인 못했음 ㅠㅠ;;
