### PR TITLE
[#82] FirebaseAuthService 회원탈퇴 추가

### DIFF
--- a/AGAMI/Sources/Extensions/Date+.swift
+++ b/AGAMI/Sources/Extensions/Date+.swift
@@ -1,0 +1,17 @@
+//
+//  Date+.swift
+//  AGAMI
+//
+//  Created by taehun on 11/1/24.
+//
+
+import SwiftUI
+
+extension Date {
+  func isWithinPast(minutes: Int) -> Bool {
+    let now = Date.now
+    let timeAgo = Date.now.addingTimeInterval(-1 * TimeInterval(60 * minutes))
+    let range = timeAgo...now
+    return range.contains(self)
+  }
+}

--- a/AGAMI/Sources/Presentation/View/Plake/PlakeListView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakeListView.swift
@@ -1,5 +1,5 @@
 //
-//  ArchiveListView.swift
+//  PlakeListView.swift
 //  AGAMI
 //
 //  Created by 박현수 on 10/14/24.
@@ -52,7 +52,7 @@ private struct ListHeader: View {
             Image(.plakeTabLogo)
             Spacer()
             Button {
-                coordinator.push(view: .newPlakeView)
+                coordinator.push(route: .newPlakeView)
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "plus.circle.fill")
@@ -216,7 +216,7 @@ private struct MakeNewPlakeCell: View {
     private var verticalSize: CGFloat { size.width * 176 / 377 }
     var body: some View {
         Button {
-            coordinator.push(view: .newPlakeView)
+            coordinator.push(route: .newPlakeView)
         } label: {
             ZStack {
                 Image(.makeNewPlakeCell)

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
@@ -67,10 +67,8 @@ final class PlakeListViewModel {
         }
     }
     
-    func deleteAccountAndSignOut() async throws {
-        let deleteSuccess = await authService.deleteAccount()
-        
-        if deleteSuccess {
+    func deleteAccountAndSignOut() async {
+        if await authService.deleteAccount() {
             logout()
         } else {
             dump("계정 삭제에 실패했습니다.")

--- a/AGAMI/Sources/Service/FirebaseAuthService.swift
+++ b/AGAMI/Sources/Service/FirebaseAuthService.swift
@@ -34,7 +34,7 @@ final class FirebaseAuthService {
     
     func registerAuthStateHandler() {
         if authStateHandler == nil {
-            authStateHandler = Auth.auth().addStateDidChangeListener { auth, user in
+            authStateHandler = Auth.auth().addStateDidChangeListener { _, user in
                 self.user = user
             }
         }
@@ -109,12 +109,12 @@ final class FirebaseAuthService {
     func deleteAccount() async -> Bool {
         guard let user = user else { return false }
         guard let lastSignInDate = user.metadata.lastSignInDate else { return false }
-        let needsReauth = !lastSignInDate.isWithinPast(minutes: 5)
+        let needsReAuth = !lastSignInDate.isWithinPast(minutes: 5)
         
         let needsTokenRevocation = user.providerData.contains { $0.providerID == "apple.com" }
         
         do {
-            if needsReauth || needsTokenRevocation {
+            if needsReAuth || needsTokenRevocation {
                 let signInWithApple = await SignInWithApple()
                 let appleIDCredential = try await signInWithApple()
                 
@@ -132,7 +132,7 @@ final class FirebaseAuthService {
                                                           idToken: idTokenString,
                                                           rawNonce: nonce)
                 
-                if needsReauth {
+                if needsReAuth {
                     try await user.reauthenticate(with: credential)
                 }
                 if needsTokenRevocation {

--- a/AGAMI/Sources/Service/FirebaseService.swift
+++ b/AGAMI/Sources/Service/FirebaseService.swift
@@ -89,12 +89,22 @@ final class FirebaseService {
         }
     }
 
+    func deleteImageInFirebase(userID: String, photoURL: String) async throws {
+        let imageIDFolder = firestorage
+                                .reference()
+                                .child("\(userID)/\(photoURL)")
+        
+        try await deleteFilesRecursively(in: imageIDFolder)
+        dump("Image files in storage successfully deleted")
+    }
+    
     func deleteAllPlaylists(userID: String) async throws {
-        let playlists = try await firestore.collection("UserID")
-            .document(userID)
-            .collection("PlaylistID")
-            .getDocuments()
-            .documents
+        let playlists = try await firestore
+                                    .collection("UserID")
+                                    .document(userID)
+                                    .collection("PlaylistID")
+                                    .getDocuments()
+                                    .documents
         
         for playlist in playlists {
             batch.deleteDocument(playlist.reference)
@@ -108,7 +118,9 @@ final class FirebaseService {
     }
     
     func deleteAllPhotoInStorage(userID: String) async throws {
-        let userIDFolder = firestorage.reference().child(userID)
+        let userIDFolder = firestorage
+                                .reference()
+                                .child(userID)
         
         try await deleteFilesRecursively(in: userIDFolder)
         dump("All files in storage successfully deleted")


### PR DESCRIPTION
## ✅ Description
- FirebaseAuthService 회원탈퇴 기능 추가
- 회원탈퇴를 시작하게 되면 firebase에 저장된 image, playlist를 순차적으로 삭제하고, firebase auth 정보와 apple 토큰을 제거하는 순서로 탈퇴가 진행됩니다.
- 조금 더 알아보니 저장된 데이터 양이 많아지면 탈퇴 시 걸리는 시간이 길어지기 때문에 앱에서는 auth 정보와 토큰만 제거하고, firebase 데이터는 firebase extension을 통해 제거 가능하다 하더군요. 아직 완벽히 방법을 아는 것이 아니라 여유가 생기면 데이터 제거 방식 바꾸도록 하겠습니다.

- ### ‼️‼️ 탈퇴하면 playlist 데이터 날라갑니다 ‼️‼️

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 큰건 아닌데 아래의의 경우 더 좋은 가독성을 위해 들여쓰기를 어떻게 하면 좋을지 궁금합니다.
![image](https://github.com/user-attachments/assets/1aba7a9e-831f-4957-a49b-446fa5b1b1e9)

## 📸 Simulator

https://github.com/user-attachments/assets/4ae4206c-b2db-4bf4-a3ee-84d29d2d9807

## 💡 Issue
- Resolved: #82
