### PR TITLE
[#99] AccountView UI 및 기능 구현

### DIFF
--- a/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
@@ -92,9 +92,9 @@ final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullS
         case let .placeListView(viewModel):
             CollectionPlaceView(viewModel: viewModel)
         case .accountView:
-            EmptyView()
+            AccountView()
         case .deleteAccountView:
-            EmptyView()
+            SignOutView()
         case let .addPlakingView(viewModel):
             AddPlakingView(viewModel: viewModel)
         case let .addPlakingShazamView(viewModel):

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -1,0 +1,266 @@
+//
+//  AccountView.swift
+//  AGAMI
+//
+//  Created by yegang on 11/2/24.
+//
+
+import SwiftUI
+
+struct AccountView: View {
+    @State var viewModel: AccountViewModel = .init()
+    
+    var body: some View {
+        ZStack {
+            Color(.pLightGray)
+                .ignoresSafeArea(.all)
+            
+            VStack(spacing: 36) {
+                //                    HeaderView()
+                ProfileView(viewModel: $viewModel)
+                InformationView(viewModel: viewModel)
+                Spacer()
+                LogoutButton(viewModel: viewModel)
+            }
+            .padding(.horizontal, 8)
+        }
+        .navigationTitle("계정")
+        .navigationBarBackButtonHidden()
+    }
+}
+
+//private struct HeaderView: View {
+//    var body: some View {
+//        HStack {
+//            Text("계정")
+//                .font(.pretendard(weight: .bold700, size: 32))
+//                .foregroundStyle(Color(.pBlack))
+//
+//            Spacer()
+//        }
+//        .padding(EdgeInsets(top: 27, leading: 8, bottom: 0, trailing: 0))
+//    }
+//}
+
+private struct ProfileView: View {
+    @Binding var viewModel: AccountViewModel
+    @State var isPresented = false
+    
+    var body: some View {
+        VStack(spacing: 11) {
+            HStack(spacing: 0) {
+                Text("프로필")
+                    .font(.pretendard(weight: .semiBold600, size: 20))
+                    .foregroundStyle(Color(.pBlack))
+                
+                Spacer()
+                
+                Button {
+                    viewModel.isEditMode.toggle()
+                } label: {
+                    Text(viewModel.isEditMode ? "완료" : "편집")
+                        .font(.pretendard(weight: .regular400, size: 16))
+                        .foregroundStyle(Color(.pPrimary))
+                }
+            }
+            .padding(.horizontal, 8)
+            
+            HStack(spacing: 0) {
+                Spacer()
+                
+                VStack(alignment: .center, spacing: 10) {
+                    Button {
+                        if viewModel.isEditMode {
+                            isPresented = true
+                        }
+                    } label: {
+                        Image(systemName: "person.crop.circle.fill")
+                            .resizable()
+                            .frame(width: 94, height: 94)
+                            .foregroundStyle(Color(.pGray2))
+                            .overlay(alignment: .bottomTrailing) {
+                                if viewModel.isEditMode {
+                                    Circle()
+                                        .frame(width: 33, height: 33, alignment: .center)
+                                        .foregroundStyle(Color(.pLightGray))
+                                        .overlay {
+                                            Image(systemName: "camera.circle.fill")
+                                                .resizable()
+                                                .frame(width: 27, height: 27, alignment: .center)
+                                                .foregroundStyle(Color(.pPrimary))
+                                        }
+                                        .offset(x: 3, y: 3)
+                                }
+                            }
+                    }
+                    .confirmationDialog("", isPresented: $isPresented) {
+                        ProfileImageDialogActions(viewModel: viewModel)
+                    }
+                    
+                    TextField(viewModel.userName, text: $viewModel.userName)
+                        .font(.pretendard(weight: .semiBold600, size: 28))
+                        .foregroundStyle(Color(.pBlack))
+                        .frame(width: 221)
+                        .multilineTextAlignment(.center)
+                        .padding(.vertical, 10)
+                        .background(
+                            viewModel.isEditMode ?
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(.pGray2))
+                            : nil
+                        )
+                        .onChange(of: viewModel.userName) { _, newValue in
+                            if newValue.count > 10 {
+                                viewModel.userName = String(newValue.prefix(9))
+                            }
+                            
+                        }
+                        .disabled(!viewModel.isEditMode)
+                }
+                
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 30)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(.pWhite))
+            )
+        }
+    }
+}
+
+private struct InformationView: View {
+    @Environment(\.openURL) private var openURL
+    let viewModel: AccountViewModel
+    
+    var body: some View {
+        VStack(spacing: 13) {
+            HStack(spacing: 0) {
+                Text("개인정보 보호")
+                    .font(.pretendard(weight: .semiBold600, size: 20))
+                    .foregroundStyle(Color(.pBlack))
+                
+                Spacer()
+            }
+            .padding(.leading, 8)
+            
+            VStack(spacing: 8) {
+                Button {
+                    if let url = URL(string: "https://posacademy.notion.site/Plake-1302b843d5af81969d94daddfac63fde?pvs=4") {
+                        openURL(url)
+                    }
+                } label: {
+                    HStack(spacing: 0) {
+                        Text("이용 약관")
+                            .font(.pretendard(weight: .medium500, size: 16))
+                            .foregroundStyle(Color(.pBlack))
+                        
+                        Spacer()
+                        
+                        Image(systemName: "arrow.forward")
+                            .font(.system(size: 17))
+                            .foregroundStyle(Color(.pPrimary))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(.pWhite))
+                    )
+                }
+                
+                Button {
+                    //TODO: - 회원 탈퇴 기능 붙이기
+                } label: {
+                    HStack(spacing: 0) {
+                        Text("회원 탈퇴")
+                            .font(.pretendard(weight: .medium500, size: 16))
+                            .foregroundStyle(Color(.pBlack))
+                        
+                        Spacer()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 0))
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(.pWhite))
+                    )
+                }
+            }
+        }
+    }
+}
+
+private struct LogoutButton: View {
+    let viewModel: AccountViewModel
+    
+    var body: some View {
+        Button {
+            //TODO: - 로그아웃 기능 붙이기
+        } label: {
+            Text("로그아웃")
+                .font(.pretendard(weight: .medium500, size: 20))
+                .foregroundStyle(Color(.pWhite))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .foregroundStyle(Color(.pPrimary))
+                )
+        }
+        .border(.red)
+        .padding(.bottom, 27)
+    }
+}
+
+private struct ProfileImageDialogActions: View {
+    let viewModel: AccountViewModel
+    
+    var body: some View {
+        Button {
+            
+        } label: {
+            Text("앨범에서 가져오기")
+                .font(.pretendard(weight: .regular400, size: 18))
+                .foregroundStyle(Color(.pBlack))
+        }
+        
+        Button {
+            
+        } label: {
+            Text("기본 이미지로 변경")
+                .font(.pretendard(weight: .regular400, size: 18))
+                .foregroundStyle(Color(.pPrimary))
+        }
+    }
+}
+
+private struct LogoutAlertActions: View {
+    let viewModel: AccountViewModel
+    
+    var body: some View {
+        Button("취소", role: .cancel) {
+            viewModel.isShowingLogoutAlert = false
+        }
+        
+        Button("확인", role: .destructive) {
+            
+        }
+    }
+}
+
+private struct SignOutAlertActions: View {
+    var body: some View {
+        Button("취소", role: .cancel) {
+            
+        }
+        
+        Button("탈퇴", role: .destructive) {
+            
+        }    }
+}
+
+#Preview {
+    AccountView()
+}

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -17,7 +17,7 @@ struct AccountView: View {
             
             VStack(spacing: 36) {
                 //                    HeaderView()
-                ProfileView(viewModel: $viewModel)
+                ProfileView(viewModel: viewModel)
                 InformationView(viewModel: viewModel)
                 Spacer()
                 LogoutButton(viewModel: viewModel)
@@ -43,8 +43,7 @@ struct AccountView: View {
 //}
 
 private struct ProfileView: View {
-    @Binding var viewModel: AccountViewModel
-    @State var isPresented = false
+    @Bindable var viewModel: AccountViewModel
     
     var body: some View {
         VStack(spacing: 11) {
@@ -71,7 +70,7 @@ private struct ProfileView: View {
                 VStack(alignment: .center, spacing: 10) {
                     Button {
                         if viewModel.isEditMode {
-                            isPresented = true
+                            viewModel.isPresented = true
                         }
                     } label: {
                         Image(systemName: "person.crop.circle.fill")
@@ -93,7 +92,7 @@ private struct ProfileView: View {
                                 }
                             }
                     }
-                    .confirmationDialog("", isPresented: $isPresented) {
+                    .confirmationDialog("", isPresented: $viewModel.isPresented) {
                         ProfileImageDialogActions(viewModel: viewModel)
                     }
                     
@@ -257,7 +256,8 @@ private struct SignOutAlertActions: View {
         
         Button("탈퇴", role: .destructive) {
             
-        }    }
+        }
+    }
 }
 
 #Preview {

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -209,7 +209,6 @@ private struct LogoutButton: View {
                         .foregroundStyle(Color(.pPrimary))
                 )
         }
-        .border(.red)
         .padding(.bottom, 27)
     }
 }

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -98,9 +98,7 @@ private struct ProfileView: View {
                 Button {
                     if viewModel.isEditMode {
                         Task {
-                            if let userName = viewModel.userName {
-                                await viewModel.saveUserName(nickname: userName)
-                            }
+                            await viewModel.saveUserName(nickname: viewModel.userName)
                             
                             if let image = viewModel.postImage {
                                 await viewModel.saveUserProfileImage(image: image)

--- a/AGAMI/Sources/Presentation/View/Account/SignOutView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/SignOutView.swift
@@ -1,0 +1,18 @@
+//
+//  SignOutView.swift
+//  AGAMI
+//
+//  Created by yegang on 11/4/24.
+//
+
+import SwiftUI
+
+struct SignOutView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    SignOutView()
+}

--- a/AGAMI/Sources/Presentation/View/Account/SignOutView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/SignOutView.swift
@@ -9,7 +9,31 @@ import SwiftUI
 
 struct SignOutView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack {
+            Color(.pLightGray)
+                .ignoresSafeArea()
+            
+            VStack(alignment: .center, spacing: 25) {
+                ZStack(alignment: .center) {
+                    Circle()
+                        .fill(Color(.pPrimary))
+                        .frame(width: 90, height: 90)
+                    
+                    Circle()
+                        .fill(Color(.pWhite))
+                        .frame(width: 82, height: 82)
+                    
+                    Image(systemName: "checkmark.circle.fill")
+                        .resizable()
+                        .frame(width: 76, height: 76)
+                        .foregroundStyle(Color(.pPrimary))
+                }
+                
+                Text("회원 탈퇴 완료!")
+                    .font(.pretendard(weight: .semiBold600, size: 24))
+                    .foregroundStyle(Color(.pBlack))
+            }
+        }
     }
 }
 

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -20,6 +20,7 @@ final class AccountViewModel {
     
     var userName: String = "가자미"
     
+    var showPhotoPicker: Bool = false
     var selectedItem: PhotosPickerItem?
     var postImage: Image?
     

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -11,24 +11,29 @@ import PhotosUI
 @Observable
 final class AccountViewModel {
     private let firebaseAuthService: FirebaseAuthService = FirebaseAuthService()
+    private let firebaseService: FirebaseService = FirebaseService()
+    
     var isScucessDeleteAccount: Bool = false
+    
     var isEditMode: Bool = false
     var isPresented: Bool = false
     
     var isShowingSignOutAlert: Bool = false
     var isDeletingAccount: Bool = false
     
-    var userName: String = "가자미"
+    var userName: String?
+    var isUserNameSaved: Bool = false
     
     var showPhotoPicker: Bool = false
     var selectedItem: PhotosPickerItem?
-    var postImage: Image?
+    var postImage: UIImage?
+    var imageURL: String?
     
     func convertImage(item: PhotosPickerItem?) async {
         guard let item = item else { return }
         guard let data = try? await item.loadTransferable(type: Data.self) else { return }
         guard let uiImage = UIImage(data: data) else { return }
-        self.postImage = Image(uiImage: uiImage)
+        self.postImage = uiImage
     }
     
     func signOut() {
@@ -55,14 +60,55 @@ final class AccountViewModel {
         }
     }
     
-    func koreaLangCheck(_ input: String) -> Bool {
-        let pattern = "^[가-힣a-zA-Z\\s]*$"
-        if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
-            let range = NSRange(location: 0, length: input.utf16.count)
-            if regex.firstMatch(in: input, options: [], range: range) != nil {
-                return true
-            }
+    func saveUserName(nickname: String) async {
+        guard let uid = FirebaseAuthService.currentUID else {
+            dump("UID를 가져오는 데 실패했습니다.")
+            return
         }
-        return false
+        do {
+            try await firebaseService.saveUserNickname(userID: uid, nickname: nickname)
+            dump("닉네임을 저장하는데 성공했습니다.")
+        } catch {
+            dump("유저 닉네임을 저장하는데 실패했습니다.")
+        }
+    }
+    
+    func fetchUserInformation() async {
+        guard let uid = FirebaseAuthService.currentUID else {
+            dump("UID를 가져오는 데 실패했습니다.")
+            return
+        }
+        
+        do {
+            let userInformation = try await firebaseService.fetchUserInformation(userID: uid)
+            
+            if let userName = userInformation["UserNickname"] as? String {
+                self.userName = userName
+            } else {
+                dump("userName 값이 String 타입이 아니거나 nil입니다.")
+            }
+            
+            if let imageURL = userInformation["UserImageURL"] as? String {
+                self.imageURL = imageURL
+            } else {
+                dump("imageURL 값이 String 타입이 아니거나 nil입니다.")
+            }
+        } catch {
+            dump("유저 정보를 불러오는데 실패했습니다.")
+        }
+    }
+    
+    func saveUserProfileImage(image: UIImage) async {
+        guard let uid = FirebaseAuthService.currentUID else {
+            dump("UID를 가져오는 데 실패했습니다.")
+            return
+        }
+        
+        do {
+            try await firebaseService.uploadUserImageToFirebase(userID: uid, image: image)
+            dump("유저 이미지를 저장하는데 성공했습니다.")
+        } catch {
+            dump("유저 이미지를 저장하는데 실패했습니다.")
+        }
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -5,9 +5,8 @@
 //  Created by yegang on 11/3/24.
 //
 
-import Foundation
-import SwiftUICore
-import _PhotosUI_SwiftUI
+import SwiftUI
+import PhotosUI
 
 @Observable
 final class AccountViewModel {

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -20,7 +20,7 @@ final class AccountViewModel {
     
     var isShowingSignOutAlert: Bool = false
     var isDeletingAccount: Bool = false
-    g
+
     var userName: String = "Plake"
     var isUserNameSaved: Bool = false
     

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -20,8 +20,8 @@ final class AccountViewModel {
     
     var isShowingSignOutAlert: Bool = false
     var isDeletingAccount: Bool = false
-    
-    var userName: String = ""
+    g
+    var userName: String = "Plake"
     var isUserNameSaved: Bool = false
     
     var showPhotoPicker: Bool = false

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -10,11 +10,15 @@ import PhotosUI
 
 @Observable
 final class AccountViewModel {
+    private let firebaseAuthService: FirebaseAuthService = FirebaseAuthService()
+    var isScucessDeleteAccount: Bool = false
     var isEditMode: Bool = false
     var isPresented: Bool = false
-    var isShowingLogoutAlert: Bool = false
     
-    var userName: String = "가자미가자미가자미"
+    var isShowingSignOutAlert: Bool = false
+    var isDeletingAccount: Bool = false
+    
+    var userName: String = "가자미"
     
     var selectedItem: PhotosPickerItem?
     var postImage: Image?
@@ -24,5 +28,40 @@ final class AccountViewModel {
         guard let data = try? await item.loadTransferable(type: Data.self) else { return }
         guard let uiImage = UIImage(data: data) else { return }
         self.postImage = Image(uiImage: uiImage)
+    }
+    
+    func signOut() {
+        firebaseAuthService.signOut { result in
+            switch result {
+            case .success:
+                UserDefaults.standard.removeObject(forKey: "isSignedIn")
+                dump("로그아웃 성공")
+            case .failure(let error):
+                dump("로그아웃 실패 \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    func deleteAccount() async {
+        let success = await firebaseAuthService.deleteAccount()
+        
+        if success {
+            isScucessDeleteAccount = true
+            UserDefaults.standard.removeObject(forKey: "isSignedIn")
+            dump("계정 삭제 성공")
+        } else {
+            dump("계정 삭제 실패")
+        }
+    }
+    
+    func koreaLangCheck(_ input: String) -> Bool {
+        let pattern = "^[가-힣a-zA-Z\\s]*$"
+        if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
+            let range = NSRange(location: 0, length: input.utf16.count)
+            if regex.firstMatch(in: input, options: [], range: range) != nil {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -21,7 +21,7 @@ final class AccountViewModel {
     var isShowingSignOutAlert: Bool = false
     var isDeletingAccount: Bool = false
     
-    var userName: String?
+    var userName: String = ""
     var isUserNameSaved: Bool = false
     
     var showPhotoPicker: Bool = false

--- a/AGAMI/Sources/Presentation/ViewModel/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/AccountViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  AccountViewModel.swift
+//  AGAMI
+//
+//  Created by yegang on 11/3/24.
+//
+
+import Foundation
+import SwiftUICore
+import _PhotosUI_SwiftUI
+
+@Observable
+final class AccountViewModel {
+    var isEditMode: Bool = false
+    var isShowingLogoutAlert: Bool = false
+    var userName: String = "가자미가자미가자미"
+    
+    var selectedItem: PhotosPickerItem?
+    var postImage: Image?
+    
+    func convertImage(item: PhotosPickerItem?) async {
+        guard let item = item else { return }
+        guard let data = try? await item.loadTransferable(type: Data.self) else { return }
+        guard let uiImage = UIImage(data: data) else { return }
+        self.postImage = Image(uiImage: uiImage)
+    }
+}

--- a/AGAMI/Sources/Presentation/ViewModel/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/AccountViewModel.swift
@@ -12,7 +12,9 @@ import _PhotosUI_SwiftUI
 @Observable
 final class AccountViewModel {
     var isEditMode: Bool = false
+    var isPresented: Bool = false
     var isShowingLogoutAlert: Bool = false
+    
     var userName: String = "가자미가자미가자미"
     
     var selectedItem: PhotosPickerItem?

--- a/AGAMI/Sources/Service/FirebaseService.swift
+++ b/AGAMI/Sources/Service/FirebaseService.swift
@@ -169,7 +169,7 @@ final class FirebaseService {
             }
         }
     }
-
+    
     func uploadUserImageToFirebase(userID: String, image: UIImage) async throws {
         guard let imageData = image.jpegData(compressionQuality: 0.7) else {
             throw NSError(domain: "ImageConversionError", code: -1, userInfo: [NSLocalizedDescriptionKey: "이미지를 데이터로 변환하는 데 실패했습니다."])
@@ -205,5 +205,26 @@ final class FirebaseService {
         
         try await deleteFilesRecursively(in: imageIDFolder)
         dump("Image files in storage successfully deleted")
+    }
+    
+    func fetchUserInformation(userID: String) async throws -> [String: Any] {
+        let documentSnapshot = try await firestore
+                                            .collection("UserInformation")
+                                            .document(userID)
+                                            .getDocument()
+        
+        guard let data = documentSnapshot.data() else {
+            throw NSError(domain: "FirestoreError", code: -1, userInfo: [NSLocalizedDescriptionKey: "사용자 데이터를 찾을 수 없습니다."])
+        }
+        
+        var result: [String: Any] = [:]
+        if let userNickname = data["UserNickname"] {
+            result["UserNickname"] = userNickname
+        }
+        if let userImageURL = data["UserImageURL"] {
+            result["UserImageURL"] = userImageURL
+        }
+        
+        return result
     }
 }


### PR DESCRIPTION
## ✅ Description
- Account 뷰 구현 했습니다. 아직 연결된 코디네이터가 없어서 연결후 NavigationTitle이 떴을 때 위치를 잡아줘야 될 거 같아요.
- 이용약관 뷰가 있었는데 저 뷰로 따로 넘어가지 않고, 바로 사파리로 넘어가서 노션 페이지를 띄워주는 것으로 변경했습니다.
- userName 같은 경우 한글로는 최대 8글자, 영어로는 16글자 까지 들어가게 수정하면 좋을 거 같아요. (현재는 10글자가 넘어가면 잘라서 9글자 까지만 저장되게 해놨습니다. TextField 에 달려있는`onChange` 참조)
- 회원탈퇴 뷰 구현 완료~
- AccountView에 `HeaderView` 가 있는데 나중에 NavigationTitle 적용된 거 보고 디자인과 다를 때 사용해야 될 수도 있을 거 같아서 주석처리 해놨습니다. (추후 네비게이션 타이틀 적용이 잘 된다면 삭제 예정)

**Alert, Dialog 쪽은 아직 구현 못 했습니다. 부탁해요 션~~**

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- Alert, Dialog 과정에서 색상이 `pPrimary` 로 고정돼서 보이는 이슈가 있습니다. 구리스가 수정해 주셨다고 하니 참고 바람.

## 📸 Simulator

https://github.com/user-attachments/assets/b3aaaa18-f4a2-4ee5-85c0-0c874daf5331



## 💡 Issue
- Resolved: #99 
