### PR TITLE
[#120] Custom Annotation 터치 영역 재설정 및 공유 버튼 제거

### DIFF
--- a/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
@@ -154,6 +154,9 @@ final class BubbleAnnotationView: MKAnnotationView {
 
             self.hostingController = hostingController
         }
+
+        self.bounds = CGRect(x: 0, y: 0, width: 65, height: 75)
+        self.centerOffset = CGPoint(x: 0, y: -37.5)
     }
 }
 
@@ -194,6 +197,9 @@ final class ClusterBubbleAnnotationView: MKAnnotationView {
 
             self.hostingController = hostingController
         }
+
+        self.bounds = CGRect(x: 0, y: 0, width: 65, height: 75)
+        self.centerOffset = CGPoint(x: 0, y: -37.5)
     }
 }
 

--- a/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
@@ -18,7 +18,7 @@ struct MKMapViewWrapper: UIViewRepresentable {
         let mapView = MKMapView()
 
         mapView.delegate = context.coordinator
-        mapView.showsUserLocation = true
+
         mapView.register(BubbleAnnotationView.self, forAnnotationViewWithReuseIdentifier: NSStringFromClass(BubbleAnnotationView.self))
         mapView.register(ClusterBubbleAnnotationView.self, forAnnotationViewWithReuseIdentifier: NSStringFromClass(ClusterBubbleAnnotationView.self))
 

--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -477,11 +477,11 @@ private struct MenuContents: View {
             Label("플레이킹 더하기", image: .menuBlackPlakeLogo)
         }
 
-        Button {
-
-        } label: {
-            Label("공유하기", systemImage: "square.and.arrow.up")
-        }
+//        Button {
+//
+//        } label: {
+//            Label("공유하기", systemImage: "square.and.arrow.up")
+//        }
 
         Button {
             Task {


### PR DESCRIPTION
## ✅ Description
- Custom Annotation 터치 영역 재설정
- 공유 버튼 제거

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 동작하지 않는 버튼이 앱에 있으면 리젝 사유라고 알고 있었는데,,, 끼워서 심사 내버렸네요
    - 그래서 지웠습니다
- `MKAnnotationView`에 추가한 서브뷰(스유로 그린 2개의 커스텀 어노테이션)가 확대 시 UIHostingController 크기보다 커지면서 터치 영역이 상대적으로 작아지는 버그가 있었습니다.
    - `ClusterBubbleAnnotationView`, `BubbleAnnotationView` bounds를 서브뷰 크기에 맞게 수정했습니다 
- 명세에 맞춰 `showsUserLocation = true` 제거했습니다

## 📸 Simulator
https://github.com/user-attachments/assets/9160cf47-3ec3-4a30-8d67-8b28230e66a2

## 💡 Issue
- Resolved: #120
