### PR TITLE
[#129] 내보내기 중일 때 계정 상태 오류 알럿 구현

### DIFF
--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -66,6 +66,11 @@ struct PlakePlaylistView: View {
         } message: {
             Text("삭제한 플레이크는 되돌릴 수 없습니다.")
         }
+        .alert("게정 상태 문제", isPresented: $viewModel.presentationState.isShowingExportingAppleMusicFailedAlert) {
+            ExportingFailedAlertActions(viewModel: viewModel)
+        } message: {
+            Text("플레이크를 내보낼 수 없습니다.\n Apple Music의 계정 상태를 확인해주세요.")
+        }
         .alert("기본 이미지로 변경", isPresented: $viewModel.presentationState.isShowingDeletePhotoAlert) {
             DeletePhotoAlertActions(viewModel: viewModel)
         } message: {
@@ -530,6 +535,22 @@ private struct DeletePlakeAlertActions: View {
                 await viewModel.deletePlaylist()
                 coordinator.pop()
             }
+        }
+    }
+}
+
+private struct ExportingFailedAlertActions: View {
+    @Environment(PlakeCoordinator.self) private var coordinator
+    let viewModel: PlakePlaylistViewModel
+
+    var body: some View {
+        Button("취소", role: .cancel) {
+            viewModel.presentationState.isShowingDeletePlakeAlert = false
+        }
+
+        Button("확인", role: .destructive) {
+            viewModel.presentationState.isShowingDeletePlakeAlert = false
+            viewModel.openAppleMusicInAppStore()
         }
     }
 }

--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -87,8 +87,7 @@ struct PlakePlaylistView: View {
         }
         .onChange(of: scenePhase) { _, newScene in
             if newScene == .active && viewModel.presentationState.didOpenSpotifyURL {
-                viewModel.exportingState = .none
-                viewModel.presentationState.didOpenSpotifyURL = false
+                viewModel.resetSpotifyURLState()
             }
         }
     }
@@ -548,6 +547,7 @@ private struct DeletePlakeAlertActions: View {
 
 private struct ExportingFailedAlertActions: View {
     @Environment(PlakeCoordinator.self) private var coordinator
+    @Environment(\.openURL) private var openURL
     let viewModel: PlakePlaylistViewModel
     
     var body: some View {
@@ -557,7 +557,9 @@ private struct ExportingFailedAlertActions: View {
         
         Button("확인", role: .destructive) {
             viewModel.presentationState.isShowingDeletePlakeAlert = false
-            viewModel.openAppleMusicInAppStore()
+            if let url = URL(string: viewModel.exportAppleMusicURLString) {
+                openURL(url)
+            }
         }
     }
 }

--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -15,6 +15,7 @@ struct PlakePlaylistView: View {
     @State var viewModel: PlakePlaylistViewModel
     @Environment(\.openURL) private var openURL
     @Environment(PlakeCoordinator.self) private var coordinator
+    @Environment(\.scenePhase) private var scenePhase
     
     init(viewModel: PlakePlaylistViewModel) {
         _viewModel = State(wrappedValue: viewModel)
@@ -83,6 +84,12 @@ struct PlakePlaylistView: View {
         )
         .onOpenURL { url in
             viewModel.handleURL(url)
+        }
+        .onChange(of: scenePhase) { _, newScene in
+            if newScene == .active && viewModel.presentationState.didOpenSpotifyURL {
+                viewModel.exportingState = .none
+                viewModel.presentationState.didOpenSpotifyURL = false
+            }
         }
     }
 }
@@ -542,12 +549,12 @@ private struct DeletePlakeAlertActions: View {
 private struct ExportingFailedAlertActions: View {
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: PlakePlaylistViewModel
-
+    
     var body: some View {
         Button("취소", role: .cancel) {
             viewModel.presentationState.isShowingDeletePlakeAlert = false
         }
-
+        
         Button("확인", role: .destructive) {
             viewModel.presentationState.isShowingDeletePlakeAlert = false
             viewModel.openAppleMusicInAppStore()

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
@@ -20,6 +20,8 @@ final class PlakePlaylistViewModel: Hashable {
         var isShowingPicker: Bool = false
         var isUpdating: Bool = false
         var isLoading: Bool = false
+        var isShowingExportingAppleMusicFailedAlert: Bool = false
+        var isShowingExportingSpotifyFailedAlert: Bool = false
     }
     let id: UUID = .init()
     
@@ -64,7 +66,7 @@ final class PlakePlaylistViewModel: Hashable {
     
     func exportPlaylistToAppleMusic() async -> URL? {
         guard await musicService.checkAppleMusicSubscriptionStatus() else {
-            print("Apple Music 구독이 필요합니다. 사용자에게 구독 안내를 표시하세요.")
+            self.presentationState.isShowingExportingAppleMusicFailedAlert = true
             return nil
         }
         
@@ -107,6 +109,12 @@ final class PlakePlaylistViewModel: Hashable {
             }
             self?.exportingState = .none
             completion(.success(playlistURL))
+        }
+    }
+    
+    func openAppleMusicInAppStore() {
+        if let url = URL(string: "itms-apps://itunes.apple.com/app/apple-music/id1108187390") {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
     }
     

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
@@ -33,6 +33,8 @@ final class PlakePlaylistViewModel: Hashable {
     var exportingState: ExportingState = .none
     var presentationState: PlaylistPresentationState = .init()
     
+    let exportAppleMusicURLString: String = "itms-apps://itunes.apple.com/app/apple-music/id1108187390"
+    
     var selectedItem: PhotosPickerItem? {
         didSet {
             Task {
@@ -111,12 +113,6 @@ final class PlakePlaylistViewModel: Hashable {
             }
             self?.exportingState = .none
             completion(.success(playlistURL))
-        }
-    }
-    
-    func openAppleMusicInAppStore() {
-        if let url = URL(string: "itms-apps://itunes.apple.com/app/apple-music/id1108187390") {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
     }
     
@@ -261,6 +257,11 @@ final class PlakePlaylistViewModel: Hashable {
                 self.playlist = newPlaylist
             }
         }
+    }
+    
+    func resetSpotifyURLState() {
+        exportingState = .none
+        presentationState.didOpenSpotifyURL = false
     }
 }
 

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
@@ -22,6 +22,7 @@ final class PlakePlaylistViewModel: Hashable {
         var isLoading: Bool = false
         var isShowingExportingAppleMusicFailedAlert: Bool = false
         var isShowingExportingSpotifyFailedAlert: Bool = false
+        var didOpenSpotifyURL = false // 백그라운드에서 포그라운드로 돌아왔을 때의 확인 변수
     }
     let id: UUID = .init()
     
@@ -92,6 +93,7 @@ final class PlakePlaylistViewModel: Hashable {
     func exportPlaylistToSpotify(completion: @escaping (Result<URL, Error>) -> Void) {
         exportingState = .isSpotifyExporting
         let musicList = playlist.songs.map { ($0.title, $0.artist) }
+        presentationState.didOpenSpotifyURL = true
         SpotifyService.shared.addPlayList(name: playlist.playlistName,
                                           musicList: musicList,
                                           description: playlist.playlistDescription) { [weak self] playlistUri in

--- a/AGAMI/Sources/Service/Export/MusicService.swift
+++ b/AGAMI/Sources/Service/Export/MusicService.swift
@@ -11,7 +11,7 @@ import MusicKit
 final class MusicService {
     private var playlist: Playlist?
     private var songs: [Song] = []
-
+    
     func requestAuthorization() async throws {
         let status = MusicAuthorization.currentStatus
         switch status {
@@ -26,48 +26,71 @@ final class MusicService {
             throw MusicAuthorizationError.denied
         }
     }
-
+    
+    // 사용자의 애플뮤직 구독상태를 확인하는 함수
+    func checkAppleMusicSubscriptionStatus() async -> Bool {
+        let authorizationStatus = await MusicAuthorization.request()
+        guard authorizationStatus == .authorized else {
+            print("Apple Music 접근 권한이 없습니다.")
+            return false
+        }
+        
+        do {
+            let subscription = try await MusicSubscription.current
+            if subscription.canPlayCatalogContent {
+                print("사용자는 Apple Music 구독 중입니다.")
+                return true
+            } else {
+                print("사용자는 Apple Music을 구독하지 않았거나 구독이 만료되었습니다.")
+                return false
+            }
+        } catch {
+            print("Apple Music 구독 상태 확인 중 오류 발생: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
     func createPlaylist(name: String, description: String) async throws {
         try await requestAuthorization()
         self.playlist = try await MusicLibrary.shared.createPlaylist(name: name, description: description, items: self.songs)
     }
-
+    
     func getCurrentPlaylistUrl() -> String? {
         return playlist?.url?.absoluteString
     }
     
     func searchSongByTitle(songTitle: String) async throws -> Song {
         try await requestAuthorization()
-
+        
         var searchRequest = MusicCatalogSearchRequest(term: songTitle, types: [Song.self])
         searchRequest.limit = 1
-
+        
         let searchResponse = try await searchRequest.response()
-
+        
         guard let song = searchResponse.songs.first else {
             throw MusicServiceError.songNotFound
         }
         
         return song
     }
-
+    
     func searchSongById(songId: String) async throws -> Song {
         try await requestAuthorization()
-
+        
         let resourceRequest = MusicCatalogResourceRequest<Song>(matching: \.id, equalTo: MusicItemID(songId))
         let searchResponse = try await resourceRequest.response()
-
+        
         guard let song = searchResponse.items.first else {
             throw MusicServiceError.songNotFound
         }
         
         return song
     }
-
+    
     func addSongToSongs(song: Song) {
         songs.append(song)
     }
-
+    
     func clearSongs() {
         songs.removeAll()
     }


### PR DESCRIPTION
## ✅ Description
- 내보내기 중일 때 게정 상태 오류 알럿 구현
- 스포티파이 웹에서 다시 앱으로 돌아왔을 때 로띠 무한 재생 버그 해결

ㄴ 디자인쌤들의 확인을 받았습니다. 야호~

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
### 🎧 스포티파이에서 로그인 웹사이트에서 다시 앱으로 돌아올 때 플리 상세뷰로 가도록 플로우 수정
`@Environment(\.scenePhase) private var scenePhase`로 뷰의 상태를 받아옵니다. 
`onChange`를 활용해서 포그라운드로 앱이 돌아왔을 때와 이전에 스포티파이 url을 열었다면 의 조건문을 생성하여
스포티파이 내보내기 로띠뷰가 무한재생 되지 않도록 했습니다. 
```
.onChange(of: scenePhase) { _, newScene in
            if newScene == .active && viewModel.presentationState.didOpenSpotifyURL {
                viewModel.exportingState = .none
                viewModel.presentationState.didOpenSpotifyURL = false
            }
        }
```


<br/>

### 🎧 애플뮤직 구독 상태 확인 함수 구현
유저의 애플 뮤직 구독상태를 확인하는 함수를 구현하여 알럿을 보여줄 수 있도록 구현했습니다. 
```
    func checkAppleMusicSubscriptionStatus() async -> Bool {
        let authorizationStatus = await MusicAuthorization.request()
        guard authorizationStatus == .authorized else {
            print("Apple Music 접근 권한이 없습니다.")
            return false
        }

        do {
            let subscription = try await MusicSubscription.current
            if subscription.canPlayCatalogContent {
                print("사용자는 Apple Music 구독 중입니다.")
                return true
            } else {
                print("사용자는 Apple Music을 구독하지 않았거나 구독이 만료되었습니다.")
                return false
            }
        } catch {
            print("Apple Music 구독 상태 확인 중 오류 발생: \(error.localizedDescription)")
            return false
        }
    }

```

## 📸 Simulator
- 애플뮤직 계정 상태 오류 알럿

https://github.com/user-attachments/assets/8c4eece2-b7b6-4f58-b3c2-063b1ffdb87a


- 스포티파이에서 로그인 웹사이트에서 다시 앱으로 돌아올 때 플리 상세뷰로 가도록 플로우 수정
![Simulator Screen Recording - iPhone 16 Pro Max - 2024-11-08 at 23 46 04](https://github.com/user-attachments/assets/e7e397a6-3be1-4c4b-8582-94a932b41e08)


## 💡 Issue
- Resolved: #129 
