### PR TITLE
[#123] AccountView 프로필 편집시 분기처리와 뷰, 뷰 모델 코드 분리

### DIFF
--- a/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
@@ -94,7 +94,7 @@ final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullS
         case .accountView:
             AccountView()
         case .deleteAccountView:
-            SignOutView()
+            DeleteAccountView()
         case let .addPlakingView(viewModel):
             AddPlakingView(viewModel: viewModel)
         case let .addPlakingShazamView(viewModel):

--- a/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
@@ -94,7 +94,7 @@ final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullS
         case .accountView:
             AccountView()
         case let .deleteAccountView(viewModel):
-            DeleteAccountView(viewModel: viewModel)
+            SignOutView(viewModel: viewModel)
         case let .addPlakingView(viewModel):
             AddPlakingView(viewModel: viewModel)
         case let .addPlakingShazamView(viewModel):

--- a/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
@@ -25,7 +25,7 @@ enum PlakeRoute: Hashable {
     case placeListView(viewModel: CollectionPlaceViewModel)
     
     case accountView
-    case deleteAccountView
+    case deleteAccountView(viewModel: AccountViewModel)
 
     var id: String {
         switch self {
@@ -93,8 +93,8 @@ final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullS
             CollectionPlaceView(viewModel: viewModel)
         case .accountView:
             AccountView()
-        case .deleteAccountView:
-            DeleteAccountView()
+        case let .deleteAccountView(viewModel):
+            DeleteAccountView(viewModel: viewModel)
         case let .addPlakingView(viewModel):
             AddPlakingView(viewModel: viewModel)
         case let .addPlakingShazamView(viewModel):

--- a/AGAMI/Sources/Extensions/UINavigationController+.swift
+++ b/AGAMI/Sources/Extensions/UINavigationController+.swift
@@ -29,7 +29,6 @@ final class PopGestureManager {
 struct PopGestureViewModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .navigationBarBackButtonHidden()
             .task {
                 PopGestureManager.shared.isPopGestureEnabled = false
             }
@@ -40,7 +39,7 @@ struct PopGestureViewModifier: ViewModifier {
 }
 
 extension View {
-    func isEnablePopGesture() -> some View {
+    func disablePopGesture() -> some View {
         modifier(PopGestureViewModifier())
     }
 }

--- a/AGAMI/Sources/Extensions/UINavigationController+.swift
+++ b/AGAMI/Sources/Extensions/UINavigationController+.swift
@@ -19,6 +19,7 @@ extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
     }
 }
 
+// 스와이프 제스처 막는 뷰 모디파이어
 final class PopGestureManager {
     static let shared = PopGestureManager()
     private init() {}

--- a/AGAMI/Sources/Extensions/UINavigationController+.swift
+++ b/AGAMI/Sources/Extensions/UINavigationController+.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
     override open func viewDidLoad() {
@@ -14,6 +15,32 @@ extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
     }
 
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return viewControllers.count > 1
+        return PopGestureManager.shared.isPopGestureEnabled && viewControllers.count > 1
+    }
+}
+
+final class PopGestureManager {
+    static let shared = PopGestureManager()
+    private init() {}
+    
+    var isPopGestureEnabled = true
+}
+
+struct PopGestureViewModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .navigationBarBackButtonHidden()
+            .task {
+                PopGestureManager.shared.isPopGestureEnabled = false
+            }
+            .onDisappear {
+                PopGestureManager.shared.isPopGestureEnabled = true
+            }
+    }
+}
+
+extension View {
+    func isEnablePopGesture() -> some View {
+        modifier(PopGestureViewModifier())
     }
 }

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -85,7 +85,6 @@ struct AccountView: View {
     }
 }
 
-// MARK: - ProfileView
 private struct ProfileView: View {
     @Bindable var viewModel: AccountViewModel
     
@@ -184,7 +183,6 @@ private struct ProfileView: View {
     }
 }
 
-// MARK: - InformationView
 private struct InformationView: View {
     @Environment(\.openURL) private var openURL
     let viewModel: AccountViewModel
@@ -247,7 +245,6 @@ private struct InformationView: View {
     }
 }
 
-// MARK: - LogoutButton View
 private struct LogoutButton: View {
     let viewModel: AccountViewModel
     
@@ -268,7 +265,6 @@ private struct LogoutButton: View {
     }
 }
 
-// MARK: - ProfileImageDialogActions
 private struct ProfileImageDialogActions: View {
     @Bindable var viewModel: AccountViewModel
     
@@ -280,18 +276,12 @@ private struct ProfileImageDialogActions: View {
                 .font(.pretendard(weight: .regular400, size: 18))
                 .foregroundStyle(Color(.pBlack))
         }
-        
-        Button {
+        Button("기본 이미지로 변경", role: .destructive) {
             viewModel.changeDefaultImage()
-        } label: {
-            Text("기본 이미지로 변경")
-                .font(.pretendard(weight: .regular400, size: 18))
-                .foregroundStyle(Color(.pPrimary))
         }
     }
 }
 
-// MARK: - SignOutAlertActions
 private struct SignOutAlertActions: View {
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel
@@ -308,7 +298,6 @@ private struct SignOutAlertActions: View {
     }
 }
 
-// MARK: - DeleteAccountAlertActions
 private struct DeleteAccountAlertActions: View {
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -177,11 +177,11 @@ private struct ProfileView: View {
                     .fill(Color(.pWhite))
             )
         }
-
+        
     }
 }
 
-//MARK: - InformationView
+// MARK: - InformationView
 private struct InformationView: View {
     @Environment(\.openURL) private var openURL
     let viewModel: AccountViewModel
@@ -244,7 +244,7 @@ private struct InformationView: View {
     }
 }
 
-//MARK: - LogoutButton View
+// MARK: - LogoutButton View
 private struct LogoutButton: View {
     let viewModel: AccountViewModel
     
@@ -265,7 +265,7 @@ private struct LogoutButton: View {
     }
 }
 
-//MARK: - ProfileImageDialogActions
+// MARK: - ProfileImageDialogActions
 private struct ProfileImageDialogActions: View {
     @Bindable var viewModel: AccountViewModel
     
@@ -288,7 +288,7 @@ private struct ProfileImageDialogActions: View {
     }
 }
 
-//MARK: - SignOutAlertActions
+// MARK: - SignOutAlertActions
 private struct SignOutAlertActions: View {
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel
@@ -305,7 +305,7 @@ private struct SignOutAlertActions: View {
     }
 }
 
-//MARK: - DeleteAccountAlertActions
+// MARK: - DeleteAccountAlertActions
 private struct DeleteAccountAlertActions: View {
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -36,7 +36,7 @@ struct AccountView: View {
                 }
                 .padding(.horizontal, 8)
             } else {
-                DeleteAccountView(viewModel: viewModel)
+                SignOutView(viewModel: viewModel)
             }
         }
         .onAppearAndActiveCheckUserValued(scenePhase)

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -147,9 +147,7 @@ private struct ProfileView: View {
                         }
                     }
                     .onTapGesture {
-                        if viewModel.isEditMode {
-                            viewModel.showProfileImageDialog()
-                        }
+                        viewModel.showProfileImageDialog()
                     }
                     
                     TextField(viewModel.userName, text: $viewModel.userName)
@@ -165,6 +163,11 @@ private struct ProfileView: View {
                                 .fill(Color(.pGray2))
                             : nil
                         )
+                        .onChange(of: viewModel.userName) { _, newValue in
+                            if newValue.count > 8 {
+                                viewModel.userName = String(newValue.prefix(8))
+                            }
+                        }
                 }
                 .disabled(!viewModel.isEditMode)
 

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -19,14 +19,16 @@ struct AccountView: View {
             Color(.pLightGray)
                 .ignoresSafeArea()
             
-            if !viewModel.isDeletingAccount {
+            if case .none = viewModel.deleteAccountProcess {
                 VStack(spacing: 0) {
                     ScrollView {
-                        profileView
+                        ProfileView(viewModel: viewModel)
                             .padding(.top, 28)
+                        
                         InformationView(viewModel: viewModel)
                             .padding(.top, 33)
                     }
+                    
                     Spacer()
                     
                     LogoutButton(viewModel: viewModel)
@@ -34,12 +36,7 @@ struct AccountView: View {
                 }
                 .padding(.horizontal, 8)
             } else {
-                DeleteAccountView()
-                    .onAppear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                            coordinator.popToRoot()
-                        }
-                    }
+                DeleteAccountView(viewModel: viewModel)
             }
         }
         .onAppearAndActiveCheckUserValued(scenePhase)
@@ -47,19 +44,19 @@ struct AccountView: View {
         .navigationBarTitleDisplayMode(.large)
         .navigationBarBackButtonHidden()
         .ignoresSafeArea(.keyboard)
-//        .toolbar {
-//            if !viewModel.isScucessDeleteAccount {
-//                ToolbarItem(placement: .topBarLeading) {
-//                    Button {
-//                        coordinator.pop()
-//                    } label: {
-//                        Image(systemName: "chevron.backward")
-//                            .font(.pretendard(weight: .semiBold600, size: 17))
-//                            .foregroundStyle(Color(.pPrimary))
-//                    }
-//                }
-//            }
-//        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                if viewModel.deleteAccountProcess == .none {
+                    Button {
+                        coordinator.pop()
+                    } label: {
+                        Image(systemName: "chevron.backward")
+                            .font(.pretendard(weight: .semiBold600, size: 17))
+                            .foregroundStyle(Color(.pPrimary))
+                    }
+                }
+            }
+        }
         .onTapGesture {
             hideKeyboard()
         }
@@ -86,9 +83,13 @@ struct AccountView: View {
             viewModel.fetchUserInformation()
         }
     }
+}
+
+// MARK: - ProfileView
+private struct ProfileView: View {
+    @Bindable var viewModel: AccountViewModel
     
-    //MARK: - 프로필 뷰
-    private var profileView: some View {
+    var body: some View {
         VStack(spacing: 11) {
             HStack(spacing: 0) {
                 Text("프로필")
@@ -176,16 +177,11 @@ struct AccountView: View {
                     .fill(Color(.pWhite))
             )
         }
-    }
-    
-    //MARK: - InformationView
-    //MARK: - LogoutButton View
-    //MARK: - ProfileImageDialogActions
-    //MARK: - SignOutAlertActions
-    //MARK: - DeleteAccountAlertActions
 
+    }
 }
 
+//MARK: - InformationView
 private struct InformationView: View {
     @Environment(\.openURL) private var openURL
     let viewModel: AccountViewModel
@@ -248,6 +244,7 @@ private struct InformationView: View {
     }
 }
 
+//MARK: - LogoutButton View
 private struct LogoutButton: View {
     let viewModel: AccountViewModel
     
@@ -268,6 +265,7 @@ private struct LogoutButton: View {
     }
 }
 
+//MARK: - ProfileImageDialogActions
 private struct ProfileImageDialogActions: View {
     @Bindable var viewModel: AccountViewModel
     
@@ -290,6 +288,7 @@ private struct ProfileImageDialogActions: View {
     }
 }
 
+//MARK: - SignOutAlertActions
 private struct SignOutAlertActions: View {
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel
@@ -306,7 +305,9 @@ private struct SignOutAlertActions: View {
     }
 }
 
+//MARK: - DeleteAccountAlertActions
 private struct DeleteAccountAlertActions: View {
+    @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel
     
     var body: some View {

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -116,41 +116,41 @@ private struct ProfileView: View {
                 Spacer()
                 
                 VStack(alignment: .center, spacing: 10) {
-                    Button {
-                        viewModel.showProfileImageDialog()
-                    } label: {
-                        Group {
-                            if let postImage = viewModel.postImage {
-                                Image(uiImage: postImage)
-                                    .resizable()
-                            } else if !viewModel.imageURL.isEmpty {
-                                KFImage(URL(string: viewModel.imageURL))
-                                    .resizable()
-                            } else {
-                                Image(systemName: "person.crop.circle.fill")
-                                    .resizable()
-                            }
-                        }
-                        .scaledToFill()
-                        .clipShape(Circle())
-                        .frame(width: 94, height: 94)
-                        .foregroundStyle(Color(.pGray2))
-                        .overlay(alignment: .bottomTrailing) {
-                            if viewModel.isEditMode {
-                                Circle()
-                                    .frame(width: 33, height: 33, alignment: .center)
-                                    .foregroundStyle(Color(.pLightGray))
-                                    .overlay {
-                                        Image(systemName: "camera.circle.fill")
-                                            .resizable()
-                                            .frame(width: 27, height: 27, alignment: .center)
-                                            .foregroundStyle(Color(.pPrimary))
-                                    }
-                                    .offset(x: 3, y: 3)
-                            }
+                    Group {
+                        if let postImage = viewModel.postImage {
+                            Image(uiImage: postImage)
+                                .resizable()
+                        } else if !viewModel.imageURL.isEmpty {
+                            KFImage(URL(string: viewModel.imageURL))
+                                .resizable()
+                        } else {
+                            Image(systemName: "person.crop.circle.fill")
+                                .resizable()
                         }
                     }
-                    .disabled(!viewModel.isEditMode)
+                    .scaledToFill()
+                    .clipShape(Circle())
+                    .frame(width: 94, height: 94)
+                    .foregroundStyle(Color(.pGray2))
+                    .overlay(alignment: .bottomTrailing) {
+                        if viewModel.isEditMode {
+                            Circle()
+                                .frame(width: 33, height: 33, alignment: .center)
+                                .foregroundStyle(Color(.pLightGray))
+                                .overlay {
+                                    Image(systemName: "camera.circle.fill")
+                                        .resizable()
+                                        .frame(width: 27, height: 27, alignment: .center)
+                                        .foregroundStyle(Color(.pPrimary))
+                                }
+                                .offset(x: 3, y: 3)
+                        }
+                    }
+                    .onTapGesture {
+                        if viewModel.isEditMode {
+                            viewModel.showProfileImageDialog()
+                        }
+                    }
                     
                     TextField(viewModel.userName, text: $viewModel.userName)
                         .font(.pretendard(weight: .semiBold600, size: 28))
@@ -165,9 +165,9 @@ private struct ProfileView: View {
                                 .fill(Color(.pGray2))
                             : nil
                         )
-                        .disabled(!viewModel.isEditMode)
                 }
-                
+                .disabled(!viewModel.isEditMode)
+
                 Spacer()
             }
             .frame(maxWidth: .infinity)

--- a/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct SignOutView: View {
     @Environment(\.scenePhase) private var scenePhase
     
+    @Environment(PlakeCoordinator.self) private var coordinator
+    let viewModel: AccountViewModel
     var body: some View {
         ZStack {
             Color(.pLightGray)
@@ -31,15 +33,26 @@ struct SignOutView: View {
                         .foregroundStyle(Color(.pPrimary))
                 }
                 
-                Text("회원 탈퇴 완료!")
-                    .font(.pretendard(weight: .semiBold600, size: 24))
-                    .foregroundStyle(Color(.pBlack))
+                switch viewModel.deleteAccountProcess {
+                case .inProgress:
+                    Text("회원 탈퇴중입니다...")
+                        .font(.pretendard(weight: .semiBold600, size: 24))
+                        .foregroundStyle(Color(.pBlack))
+                default:
+                    Text("회원 탈퇴 완료!")
+                        .font(.pretendard(weight: .semiBold600, size: 24))
+                        .foregroundStyle(Color(.pBlack))
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                UserDefaults.standard.removeObject(forKey: "isSignedIn")
+                                coordinator.popToRoot()
+                            }
+                        }
+                }
             }
         }
         .onAppearAndActiveCheckUserValued(scenePhase)
+        .navigationTitle("")
+        .isEnablePopGesture()
     }
-}
-
-#Preview {
-    DeleteAccountView()
 }

--- a/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
@@ -41,5 +41,5 @@ struct SignOutView: View {
 }
 
 #Preview {
-    SignOutView()
+    DeleteAccountView()
 }

--- a/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
@@ -1,5 +1,5 @@
 //
-//  SignOutView.swift
+//  DeleteAccountView.swift
 //  AGAMI
 //
 //  Created by yegang on 11/4/24.

--- a/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 struct SignOutView: View {
-    @Environment(\.scenePhase) private var scenePhase
-    
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel
+    
     var body: some View {
         ZStack {
             Color(.pLightGray)
@@ -51,8 +50,7 @@ struct SignOutView: View {
                 }
             }
         }
-        .onAppearAndActiveCheckUserValued(scenePhase)
         .navigationTitle("")
-        .isEnablePopGesture()
+        .disablePopGesture()
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -85,8 +85,8 @@ extension AccountViewModel {
         isShowingSignOutAlert = true
     }
     
-    func signOut() {
-        firebaseAuthService.signOut { result in
+    func signOutUserID() {
+        FirebaseAuthService.signOut { result in
             switch result {
             case .success:
                 UserDefaults.standard.removeObject(forKey: "isSignedIn")
@@ -108,12 +108,14 @@ extension AccountViewModel {
     }
     
     func deleteAccount() async throws {
-        guard let uid = FirebaseAuthService.currentUID else {
+        guard FirebaseAuthService.currentUID != nil else {
             dump("UID를 가져오는 데 실패했습니다.")
             return
         }
         
-        let success = await firebaseAuthService.deleteAccount()
+        let success = await firebaseAuthService.deleteAccount(changeProgress: { })
+    }
+        
     func deleteAccount() {
         Task {
             let success = await firebaseAuthService.deleteAccount {
@@ -153,7 +155,7 @@ extension AccountViewModel {
     }
     
     func confirmSignOut() {
-        signOut()
+        signOutUserID()
         isShowingSignOutAlert = false
     }
     

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -164,7 +164,9 @@ extension AccountViewModel {
     }
     
     func showProfileImageDialog() {
-        isProfileImageDialogPresented = true
+        if isEditMode {
+            isProfileImageDialogPresented = true
+        }
     }
     
     func deleteAccountButtonTapped() {

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -13,21 +13,24 @@ final class AccountViewModel {
     private let firebaseAuthService: FirebaseAuthService = FirebaseAuthService()
     private let firebaseService: FirebaseService = FirebaseService()
     
+    // 회원탈퇴 여부
     var isScucessDeleteAccount: Bool = false
     
+    // 편집 모드 여부
     var isEditMode: Bool = false
     
     var isProfileImageDialogPresented: Bool = false
     var isShowingSignOutAlert: Bool = false
     var isDeletingAccount: Bool = false
-
+    var isDefaultImage: Bool = false
+    var isProfileImageChanged: Bool = false
+    
+    // 유저 프로필 이름
     var userName: String = "닉네임"
     var editingUserName = ""
     
-    var isDefaultImage: Bool = false
-    var isProfileImageChanged: Bool = false
-
-    var showPhotoPicker: Bool = false
+    // 유저 프로필 이미지
+    var isShowPhotoPicker: Bool = false
     var selectedItem: PhotosPickerItem?
     var postImage: UIImage?
     var imageURL: String = ""
@@ -72,6 +75,10 @@ final class AccountViewModel {
 
 /// 로그인 로그아웃
 extension AccountViewModel {
+    
+    func logoutButtonTapped() {
+        isShowingSignOutAlert = true
+    }
     
     func signOut() {
         firebaseAuthService.signOut { result in
@@ -125,13 +132,38 @@ extension AccountViewModel {
         isDefaultImage = true
     }
     
-    func startEditButtonTaped() {
+    func albumButtonTapped() {
+        isShowPhotoPicker.toggle()
+    }
+    
+    func startEditButtonTapped() {
         editingUserName = userName
         
         isEditMode = true
     }
     
-    func endEditButtonTaped() {
+    func cancelSignOutAlert() {
+        isShowingSignOutAlert = false
+    }
+    
+    func confirmSignOut() {
+        signOut()
+        isShowingSignOutAlert = false
+    }
+    
+    func cancelDeleteAccountAlert() {
+        isDeletingAccount = false
+    }
+    
+    func showProfileImageDialog() {
+        isProfileImageDialogPresented = true
+    }
+    
+    func deleteAccountButtonTapped() {
+        isDeletingAccount = true
+    }
+    
+    func endEditButtonTapped() {
         Task {
             if userName != editingUserName {
                 await saveUserName(nickname: userName)

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -106,24 +106,24 @@ extension AccountViewModel {
         try await firebaseService.deleteAllPlaylists(userID: uid)
         try await firebaseService.deleteAllPhotoInStorage(userID: uid)
     }
-    
-    func deleteAccount() async throws {
-        guard FirebaseAuthService.currentUID != nil else {
+        
+    func deleteAccount() {
+        guard let uid = FirebaseAuthService.currentUID else {
             dump("UID를 가져오는 데 실패했습니다.")
             return
         }
         
-        let success = await firebaseAuthService.deleteAccount(changeProgress: { })
-    }
-        
-    func deleteAccount() {
         Task {
+            try await deleteFirebaseData()
+            
             let success = await firebaseAuthService.deleteAccount {
                 self.deleteAccountProcess = .inProgress
             }
+            
             if success {
-                dump("계정 삭제 성공")
+                try await firebaseService.saveIsUserValued(userID: uid, isUserValued: false)
                 deleteAccountProcess = .finished
+                dump("계정 삭제 성공")
             } else {
                 dump("계정 삭제 실패")
             }
@@ -180,7 +180,7 @@ extension AccountViewModel {
             if isProfileImageChanged, let image = postImage {
                 await savePhotoImageToFirebase(image: image)
                 isProfileImageChanged = false
-                dump("해냈냐?")
+                dump("유저 프로필 사진이 변경되었습니다.")
             }
             
             if isDefaultImage {
@@ -188,7 +188,7 @@ extension AccountViewModel {
                 postImage = nil
                 imageURL = ""
                 isDefaultImage = false
-                dump("제거했냐")
+                dump("유저 프로필 사진이 기본 사진으로 변경되었습니다. (사진 제거)")
             }
 
             fetchUserInformation()

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -12,9 +12,15 @@ import PhotosUI
 final class AccountViewModel {
     private let firebaseAuthService: FirebaseAuthService = FirebaseAuthService()
     private let firebaseService: FirebaseService = FirebaseService()
+
+    // 계정 삭제에 대한 상태
+    enum DeleteAccountProcess {
+        case none
+        case inProgress
+        case finished
+    }
     
-    // 회원탈퇴 여부
-    var isScucessDeleteAccount: Bool = false
+    var deleteAccountProcess: DeleteAccountProcess = .none
     
     // 편집 모드 여부
     var isEditMode: Bool = false
@@ -26,7 +32,7 @@ final class AccountViewModel {
     var isProfileImageChanged: Bool = false
     
     // 유저 프로필 이름
-    var userName: String = "닉네임"
+    var userName: String = "Plake"
     var editingUserName = ""
     
     // 유저 프로필 이미지
@@ -75,7 +81,6 @@ final class AccountViewModel {
 
 /// 로그인 로그아웃
 extension AccountViewModel {
-    
     func logoutButtonTapped() {
         isShowingSignOutAlert = true
     }
@@ -111,11 +116,12 @@ extension AccountViewModel {
         let success = await firebaseAuthService.deleteAccount()
     func deleteAccount() {
         Task {
-            let success = await firebaseAuthService.deleteAccount()
-            
+            let success = await firebaseAuthService.deleteAccount {
+                self.deleteAccountProcess = .inProgress
+            }
             if success {
-                isScucessDeleteAccount = true
                 dump("계정 삭제 성공")
+                deleteAccountProcess = .finished
             } else {
                 dump("계정 삭제 실패")
             }

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -146,7 +146,6 @@ extension AccountViewModel {
     
     func startEditButtonTapped() {
         editingUserName = userName
-        
         isEditMode = true
     }
     

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -122,12 +122,6 @@ extension AccountViewModel {
         postImage = nil
         imageURL = ""
         
-        if success {
-            try await firebaseService.saveIsUserValued(userID: uid, isUserValued: false)
-            dump("계정 삭제 성공")
-            isScucessDeleteAccount = true
-        } else {
-            dump("계정 삭제 실패")
         isDefaultImage = true
     }
     

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
@@ -54,28 +54,6 @@ final class PlakeListViewModel {
         searchText = ""
     }
 
-    func deleteAllDataInFirebase() async throws {
-        guard let userID = FirebaseAuthService.currentUID else {
-            dump("UID를 가져오는 데 실패했습니다.")
-            return
-        }
-        
-        do {
-            try await firebaseService.deleteAllPhotoInStorage(userID: userID)
-            try await firebaseService.deleteAllPlaylists(userID: userID)
-        } catch {
-            dump("\(error.localizedDescription) while deleting account")
-        }
-    }
-    
-    func deleteAccountAndSignOut() async {
-        if await authService.deleteAccount() {
-            FirebaseAuthService.signOutUserID()
-        } else {
-            dump("계정 삭제에 실패했습니다.")
-        }
-    }
-
     private func sortPlaylistsByDate(_ playlistModels: [PlaylistModel]) -> [PlaylistModel] {
         playlistModels.sorted { $0.generationTime > $1.generationTime }
     }

--- a/AGAMI/Sources/Service/Firebase/FirebaseAuthService.swift
+++ b/AGAMI/Sources/Service/Firebase/FirebaseAuthService.swift
@@ -136,7 +136,7 @@ final class FirebaseAuthService {
         }
     }
 
-    func deleteAccount() async -> Bool {
+    func deleteAccount(changeProgress: @escaping () -> Void) async -> Bool {
         guard let user = user else { return false }
         guard let lastSignInDate = user.metadata.lastSignInDate else { return false }
         let needsReAuth = !lastSignInDate.isWithinPast(minutes: 5)
@@ -147,6 +147,8 @@ final class FirebaseAuthService {
             if needsReAuth || needsTokenRevocation {
                 let signInWithApple = await SignInWithApple()
                 let appleIDCredential = try await signInWithApple()
+                
+                changeProgress()
                 
                 guard let appleIDToken = appleIDCredential.identityToken else {
                     dump("Unable to fetdch identify token.")

--- a/AGAMI/Sources/Service/Firebase/FirebaseService.swift
+++ b/AGAMI/Sources/Service/Firebase/FirebaseService.swift
@@ -205,6 +205,11 @@ final class FirebaseService {
                                 .child("\(userID)/UserImage")
         
         try await deleteFilesRecursively(in: imageIDFolder)
+        
+        try await firestore
+                    .collection("UserInformation")
+                    .document(userID)
+                    .updateData(["UserImageURL": ""])
         dump("Image files in storage successfully deleted")
     }
     


### PR DESCRIPTION
## ✅ Description
- 기존 프로필 확인 버튼을 눌렀을 때 유저 이름, 사진이 같이 저장되는 기능을 분기처리 했습니다.
- 나중에 코드를 봤을 때 유지보수 하기 쉽게 하려고 `viewModel` 파일에서 로그인, 로그아웃 회원의 Auth를 관리하는 부분과 프로필 편집하는 부분을 extension으로 빼놨어요~ (이렇게 하는게 맞는지 궁금합니다.)
ex) 이름만 변경시 이름만 저장, 사진만 변경시 사진만 저장
- 기존에 프로필 이미지 바꾸는 부분이 Button() 으로 되어있었는데 Image + `onTapGesture` 로 수정했습니다.

- 뷰 코드에 ViewModel에 있어야 될 코드들이 많은 거 같아서 수정했습니다.
- 추후 FirebaseService 코드도 수정이 필요할 거 같습니다.

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
`AccountView File`
<img width="702" alt="image" src="https://github.com/user-attachments/assets/1f79c767-26f9-42e7-a610-d09c02e88329">
- 기존 Button() 으로 되어 있는 유저 프로필 이미지 부분을 Image + `onTapGesture` 로 수정했는데 onTapGesture 가 맨 아래 있다 보니까 보기가 안 좋은 거 같은데 위치를 바꾼다던지 보기 편한 방법으로 바꿀 수 있는 부분이 있을까요?


<img width="603" alt="image" src="https://github.com/user-attachments/assets/6acc98d2-5208-4b1d-8685-bc4ac022c862">

- 유저 닉네임을 바꾸는 로직이 현재 편집 모드에 들어 갔을 때 `editingUserName` 에 현재 닉네임이 저장되고 편집한 닉네임이랑 기존에 있던 닉네임이랑 다를 때만 저장해주도록 해두었는데, 이렇게 했을 때 닉네임이 8글자가 넘지 않게 하는 로직을 View에서 `.onChange` 를 통해 비교해주고 있는데 ViewModel로 빼고 싶은데 좋은 아이디어 있으면 알려주세요.. (didSet이나 Combine을 사용하면 된다고 들었는데 어떻게 더 좋은 방법인지 모르겠습니다.)

`FirebaseAuthService File`
<img width="905" alt="스크린샷 2024-11-13 오후 2 47 01" src="https://github.com/user-attachments/assets/aca2a733-43c1-4bbf-b39a-d5af3701e005">

`AccountViewModel File`
<img width="834" alt="스크린샷 2024-11-13 오후 2 53 26" src="https://github.com/user-attachments/assets/150c0149-e127-4832-8105-902311956ff8">
- viewModel에서 유저 삭제 버튼이 확인되고, 애플 로그인이 완료된 시점에 `self.deleteAccountProcess = .inProgress` 값을 바꿔주고 완료가 되면 `deleteAccountProcess = .finished` 으로 바꿔주면서 회원탈퇴 로직 구현 완료.
- 회원탈퇴 할 때 애플 로그인 창이 내려 갔을 때의 시점에 회원 탈퇴뷰로 넘어가는 로직을 `@escaping` 을 통해 구현 완룡 (대박~!)

`UINavigationController+ File`
<img width="802" alt="image" src="https://github.com/user-attachments/assets/ee678e29-3fcf-4f82-bcbf-b84469a9200e">

`DeleteAccountView File`
<img width="299" alt="image" src="https://github.com/user-attachments/assets/579aac02-4d80-47c3-b3a7-eceb691cdf43">

- 기존에 있던 스와이프 제스처 코드에서 PopGestureManager 를 싱글톤으로 생성한 뒤 뷰 모디파이어로 만들어줬습니다.
- 아래있는 사진처럼 `.disablePopGesture()` 를 선언하면 제스처를 안 되게 막을 수 있어요!

## 📸 Simulator
![image](https://github.com/user-attachments/assets/fa804314-b8b8-497f-801f-922b1b4d64ca)
- 뷰에서 이미지가 바뀌었을 때, 파이어베이스에 이미지가 있을 때, 기본 이미지 일 때 처리 해줬습니다.

![image](https://github.com/user-attachments/assets/f8b3b93c-a78b-4c57-9f34-5b5cfa6369d6)
- 뷰 모델에서 editMode가 닫힐 때 편집한 데이터가 있는지 확인하고, 편집한 데이터가 있다면 그 데이터만 수정되게 수정했습니다.








## 💡 Issue
- Resolved: #123 
