### PR TITLE
[#124] UserValuedCheck 구현

### DIFF
--- a/AGAMI/Sources/Extensions/View+.swift
+++ b/AGAMI/Sources/Extensions/View+.swift
@@ -37,4 +37,30 @@ extension View {
             self
         }
     }
+    
+    func onAppearAndActiveCheckUserValued(_ scenePhase: ScenePhase) -> some View {
+            self
+                .onAppear {
+                    Task {
+                        do {
+                            try await FirebaseAuthService.checkUserValued()
+                            dump("User valued status is checked successfully on appear.")
+                        } catch {
+                            dump("Error checking user valued status on appear: \(error.localizedDescription)")
+                        }
+                    }
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    if newPhase == .active {
+                        Task {
+                            do {
+                                try await FirebaseAuthService.checkUserValued()
+                                dump("User valued status is checked successfully in active state.")
+                            } catch {
+                                dump("Error checking user valued status in active state: \(error.localizedDescription)")
+                            }
+                        }
+                    }
+                }
+        }
 }

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -11,6 +11,7 @@ import Kingfisher
 
 struct AccountView: View {
     @State var viewModel: AccountViewModel = .init()
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
     
     var body: some View {
@@ -42,6 +43,7 @@ struct AccountView: View {
                     }
             }
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .navigationTitle("계정")
         .navigationBarTitleDisplayMode(.large)
         .navigationBarBackButtonHidden()
@@ -315,7 +317,7 @@ private struct SignOutAlertActions: View {
         }
         
         Button("확인", role: .destructive) {
-            viewModel.signOut()
+            viewModel.signOutUserID()
             viewModel.isShowingSignOutAlert = false
         }
     }
@@ -331,7 +333,8 @@ private struct DeleteAccountAlertActions: View {
         
         Button("탈퇴", role: .destructive) {
             Task {
-                await viewModel.deleteAccount()
+                try await viewModel.deleteFirebaseData()
+                try await viewModel.deleteAccount()
             }
         }
     }

--- a/AGAMI/Sources/Presentation/View/Account/SignOutView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/SignOutView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SignOutView: View {
+    @Environment(\.scenePhase) private var scenePhase
+    
     var body: some View {
         ZStack {
             Color(.pLightGray)
@@ -34,6 +36,7 @@ struct SignOutView: View {
                     .foregroundStyle(Color(.pBlack))
             }
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
     }
 }
 

--- a/AGAMI/Sources/Presentation/View/Home/HomeView.swift
+++ b/AGAMI/Sources/Presentation/View/Home/HomeView.swift
@@ -10,6 +10,7 @@ import FirebaseAuth
 
 struct HomeView: View {
     @State private var viewModel: HomeViewModel = .init()
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
     @Environment(ListCellPlaceholderModel.self) private var listCellPlaceholder
     
@@ -85,6 +86,7 @@ struct HomeView: View {
             .padding(.bottom, 50)
             
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .ignoresSafeArea(edges: .bottom)
     }
 }

--- a/AGAMI/Sources/Presentation/View/Map/CollectionPlaceView.swift
+++ b/AGAMI/Sources/Presentation/View/Map/CollectionPlaceView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CollectionPlaceView: View {
     @State var viewModel: CollectionPlaceViewModel
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
 
     init(viewModel: CollectionPlaceViewModel) {
@@ -52,5 +53,6 @@ struct CollectionPlaceView: View {
             .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
             .navigationBarBackButtonHidden(true)
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
     }
 }

--- a/AGAMI/Sources/Presentation/View/Map/MapView.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MapView.swift
@@ -10,9 +10,11 @@ import MapKit
 
 struct MapView: View {
     @State private var viewModel: MapViewModel = MapViewModel()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         MKMapViewWrapper(viewModel: viewModel)
+            .onAppearAndActiveCheckUserValued(scenePhase)
             .ignoresSafeArea()
             .onAppear {
                 viewModel.fecthPlaylists()

--- a/AGAMI/Sources/Presentation/View/Plake/AddPlakingShazamView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/AddPlakingShazamView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct AddPlakingShazamView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AddPlakingViewModel
 
@@ -71,6 +72,7 @@ struct AddPlakingShazamView: View {
                     .padding(.bottom, 13)
             }
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .navigationBarBackButtonHidden()
         .onAppear {
             viewModel.startRecognition()

--- a/AGAMI/Sources/Presentation/View/Plake/AddPlakingView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/AddPlakingView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct AddPlakingView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
     @State var viewModel: AddPlakingViewModel
 
@@ -44,6 +45,7 @@ struct AddPlakingView: View {
 
             ShazamButton(viewModel: viewModel)
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .navigationTitle("플레이킹 더하기")
         .navigationBarTitleDisplayMode(.large)
         .toolbarVisibilityForVersion(.hidden, for: .tabBar)

--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -16,7 +16,6 @@ struct PlakePlaylistView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.openURL) private var openURL
     @Environment(PlakeCoordinator.self) private var coordinator
-    @Environment(\.scenePhase) private var scenePhase
     
     init(viewModel: PlakePlaylistViewModel) {
         _viewModel = State(wrappedValue: viewModel)

--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -13,6 +13,7 @@ import PhotosUI
 
 struct PlakePlaylistView: View {
     @State var viewModel: PlakePlaylistViewModel
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(\.openURL) private var openURL
     @Environment(PlakeCoordinator.self) private var coordinator
     @Environment(\.scenePhase) private var scenePhase
@@ -36,6 +37,7 @@ struct PlakePlaylistView: View {
                 ProgressView()
             }
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .onTapGesture { hideKeyboard() }
         .refreshable { viewModel.refreshPlaylist() }
         .background(Color(.pLightGray))

--- a/AGAMI/Sources/Presentation/View/Search/SearchShazamingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchShazamingView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SearchShazamingView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
     @State private var viewModel: SearchShazamingViewModel = SearchShazamingViewModel()
     
@@ -75,6 +76,7 @@ struct SearchShazamingView: View {
                     .padding(.bottom, 13)
             }
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .navigationBarBackButtonHidden()
         .onAppear {
             viewModel.startRecognition()

--- a/AGAMI/Sources/Presentation/View/Search/SearchStartView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchStartView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SearchStartView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
     @State private var viewModel: SearchStartViewModel = SearchStartViewModel()
     
@@ -51,6 +52,7 @@ struct SearchStartView: View {
             .background(Color(.pLightGray))
         }
         .ignoresSafeArea(.keyboard)
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .onAppear {
             viewModel.requestCurrentLocation()
             viewModel.loadSavedSongs()

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import PhotosUI
 
 struct SearchWritingView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(PlakeCoordinator.self) private var coordinator
     @Environment(ListCellPlaceholderModel.self) private var listCellPlaceholder
     @State var viewModel: SearchWritingViewModel
@@ -54,6 +55,7 @@ struct SearchWritingView: View {
             }
             
         }
+        .onAppearAndActiveCheckUserValued(scenePhase)
         .confirmationDialog("", isPresented: $viewModel.showSheet) {
             Button("카메라") {
                 coordinator.push(route: .cameraView(

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -36,8 +36,8 @@ final class AccountViewModel {
         self.postImage = uiImage
     }
     
-    func signOut() {
-        firebaseAuthService.signOut { result in
+    func signOutUserID() {
+        FirebaseAuthService.signOut { result in
             switch result {
             case .success:
                 UserDefaults.standard.removeObject(forKey: "isSignedIn")
@@ -48,12 +48,28 @@ final class AccountViewModel {
         }
     }
     
-    func deleteAccount() async {
+    func deleteFirebaseData() async throws {
+        guard let uid = FirebaseAuthService.currentUID else {
+            dump("UID를 가져오는 데 실패했습니다.")
+            return
+        }
+        
+        try await firebaseService.deleteAllPlaylists(userID: uid)
+        try await firebaseService.deleteAllPhotoInStorage(userID: uid)
+    }
+    
+    func deleteAccount() async throws {
+        guard let uid = FirebaseAuthService.currentUID else {
+            dump("UID를 가져오는 데 실패했습니다.")
+            return
+        }
+        
         let success = await firebaseAuthService.deleteAccount()
         
         if success {
-            isScucessDeleteAccount = true
+            try await firebaseService.saveIsUserValued(userID: uid, isUserValued: false)
             dump("계정 삭제 성공")
+            isScucessDeleteAccount = true
         } else {
             dump("계정 삭제 실패")
         }

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
@@ -43,17 +43,6 @@ final class PlakeListViewModel {
         searchText = ""
     }
 
-    func logout() {
-        authService.signOut { result in
-            switch result {
-            case .success:
-                UserDefaults.standard.removeObject(forKey: "isSignedIn")
-            case .failure(let err):
-                dump(err.localizedDescription)
-            }
-        }
-    }
-
     func deleteAllDataInFirebase() async throws {
         guard let userID = FirebaseAuthService.currentUID else {
             dump("UID를 가져오는 데 실패했습니다.")
@@ -70,7 +59,7 @@ final class PlakeListViewModel {
     
     func deleteAccountAndSignOut() async {
         if await authService.deleteAccount() {
-            logout()
+            FirebaseAuthService.signOutUserID()
         } else {
             dump("계정 삭제에 실패했습니다.")
         }
@@ -169,7 +158,6 @@ final class PlakeListViewModel {
             exportingState = .none
         }
     }
-
     
 // MARK: - FirebaseListner 코드
 //    private let listenerService = FirebaseListenerService()

--- a/AGAMI/Sources/Service/Firebase/FirebaseService.swift
+++ b/AGAMI/Sources/Service/Firebase/FirebaseService.swift
@@ -224,7 +224,23 @@ final class FirebaseService {
         if let userImageURL = data["UserImageURL"] {
             result["UserImageURL"] = userImageURL
         }
-        
         return result
+    }
+    
+    func saveIsUserValued(userID: String, isUserValued: Bool) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            firestore
+                .collection("UserInformation")
+                .document(userID)
+                .setData(["isUserValued": isUserValued]) { error in
+                if let error = error {
+                    dump("Failed to save isUserValued: \(error.localizedDescription)")
+                    continuation.resume(throwing: error)
+                } else {
+                    dump("isUserValued successfully saved to Firestore!")
+                    continuation.resume(returning: ())
+                }
+            }
+        }
     }
 }

--- a/AGAMI/Sources/Service/Firebase/FirebaseService.swift
+++ b/AGAMI/Sources/Service/Firebase/FirebaseService.swift
@@ -158,7 +158,8 @@ final class FirebaseService {
             firestore
                 .collection("UserInformation")
                 .document(userID)
-                .setData(["UserNickname": nickname]) { error in
+                .setData(["UserNickname": nickname], merge: true) { error in
+                    
                 if let error = error {
                     dump("Failed to save UserNickname: \(error.localizedDescription)")
                     continuation.resume(throwing: error)
@@ -232,7 +233,7 @@ final class FirebaseService {
             firestore
                 .collection("UserInformation")
                 .document(userID)
-                .setData(["isUserValued": isUserValued]) { error in
+                .setData(["isUserValued": isUserValued], merge: true) { error in
                 if let error = error {
                     dump("Failed to save isUserValued: \(error.localizedDescription)")
                     continuation.resume(throwing: error)


### PR DESCRIPTION
## ✅ Description
- 회원 탈퇴하게 되면 firebase 삭제하도록 service에 있는 함수 추가했습니다.
- 회원 탈퇴, 로그인을 하게되면 firebase store/UserInforamtion/UserID/isUserValued를 상황에 맞게 변경하게 됩니다. 이 값을 onAppear, onChange를 통해 view가 생성되거나 active 될 때 확인하여 유저를 로그인view로 이동시킬지 결정하게 됩니다.
- xcode 시뮬레이터의 경우 일반적인 아이디 생성이 불가한 것으로 확인 되었습니다. 따라서 로그인, auth 관련 로직은 될 수 있으면 핸드폰을 통해 확인해주시길 바랍니다.

## ⭐️ PR Point
- 함수를 service에서 static로 선언하고 view extension을 활용해 불러오게 되는데 이런 선택을 하기까지 많은 시도들이 있었습니다. 혹시 다른 좋은 방식이 있다면 첨언 부탁드립니다. 감사합니다.

## 📸 Simulator


## 💡 Issue
- Resolved: #124 
