### PR TITLE
[#143] 플레이크 생성 시 이미지 용량 관련 오류 수정

### DIFF
--- a/AGAMI/Sources/Service/Firebase/FirebaseService.swift
+++ b/AGAMI/Sources/Service/Firebase/FirebaseService.swift
@@ -69,21 +69,43 @@ final class FirebaseService {
             return nil
         }
     }
-
+    
     func uploadImageToFirebase(userID: String, image: UIImage) async throws -> String {
-        guard let imageData = image.jpegData(compressionQuality: 0.7) else {
+        guard let resizedImage = resizeImage(image: image, targetSize: CGSize(width: 1024, height: 1024)),
+              let imageData = resizedImage.jpegData(compressionQuality: 0.7) else {
             throw NSError(domain: "ImageConversionError", code: -1, userInfo: [NSLocalizedDescriptionKey: "이미지를 데이터로 변환하는 데 실패했습니다."])
         }
 
         let uniqueID = UUID().uuidString
-        let storageRef = firestorage.reference()
+        let storageRef = Storage.storage().reference()
             .child("\(userID)/\(uniqueID)/image.jpg")
+        
+        do {
+            _ = try await storageRef.putDataAsync(imageData, metadata: nil)
+            
+            let downloadURL = try await storageRef.downloadURL()
+            return downloadURL.absoluteString
+        } catch {
+            print("Failed to upload image to Firebase: \(error)")
+            throw error
+        }
+    }
 
-        _ = try await storageRef.putDataAsync(imageData, metadata: nil)
-
-        let downloadURL = try await storageRef.downloadURL()
-
-        return downloadURL.absoluteString
+    // 이미지 크기 조정 함수
+    func resizeImage(image: UIImage, targetSize: CGSize) -> UIImage? {
+        let size = image.size
+        let widthRatio = targetSize.width / size.width
+        let heightRatio = targetSize.height / size.height
+        let newSize = widthRatio < heightRatio
+            ? CGSize(width: size.width * widthRatio, height: size.height * widthRatio)
+            : CGSize(width: size.width * heightRatio, height: size.height * heightRatio)
+        
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+        image.draw(in: CGRect(origin: .zero, size: newSize))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return newImage
     }
 
     func deletePlaylist(userID: String, playlistID: String) async throws {


### PR DESCRIPTION
## ✅ Description
- 플레이크 생성 시 이미지 용량 관련 오류 수정했습니다. 

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
### FirebaseService 내 이미지 사이즈 조정
#### 원인
<img width="1050" alt="image" src="https://github.com/user-attachments/assets/e1258271-1439-4b3b-88a1-fcb48cd5ab5c">
플레이크가 생성되고 이미지가 올라갈 때 용량이 너무 커서 앱 크래쉬가 발생했습니다. 

#### 해결
`FirebaseService` 내에 이미지를 올릴 때 이미지 사이즈를 조정하는 함수를 추가했습니다. 

```
// 이미지 크기 조정 함수
    func resizeImage(image: UIImage, targetSize: CGSize) -> UIImage? {
        let size = image.size
        let widthRatio = targetSize.width / size.width
        let heightRatio = targetSize.height / size.height
        let newSize = widthRatio < heightRatio
            ? CGSize(width: size.width * widthRatio, height: size.height * widthRatio)
            : CGSize(width: size.width * heightRatio, height: size.height * heightRatio)
        
        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
        image.draw(in: CGRect(origin: .zero, size: newSize))
        let newImage = UIGraphicsGetImageFromCurrentImageContext()
        UIGraphicsEndImageContext()
        
        return newImage
    }
```

`uploadImageToFirebase`내에 이미지를 그대로 올리는 것이 아닌 사이즈를 따로 지정해서 올릴 수 있도록 수정했습니다. 
```
func uploadImageToFirebase(userID: String, image: UIImage) async throws -> String {
        guard let resizedImage = resizeImage(image: image, targetSize: CGSize(width: 1024, height: 1024)),
              let imageData = resizedImage.jpegData(compressionQuality: 0.7) else {
            throw NSError(domain: "ImageConversionError", code: -1, userInfo: [NSLocalizedDescriptionKey: "이미지를 데이터로 변환하는 데 실패했습니다."])
        }
```

## 📸 Simulator
- 로그 찍어서 이미지 잘 올라가는 것까지 확인 완료했습니다. 

https://github.com/user-attachments/assets/8eb60094-508a-4a6f-9548-f2cd8bfb7c81



## 💡 Issue
- Resolved: #143 
