### PR TITLE
[145] 스프린트 2차 디자인 수정 반영

### DIFF
--- a/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
@@ -94,7 +94,7 @@ final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullS
         case .accountView:
             AccountView()
         case let .deleteAccountView(viewModel):
-            SignOutView(viewModel: viewModel)
+            DeleteAccountView(viewModel: viewModel)
         case let .addPlakingView(viewModel):
             AddPlakingView(viewModel: viewModel)
         case let .addPlakingShazamView(viewModel):

--- a/AGAMI/Sources/Presentation/View/Account/AccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/AccountView.swift
@@ -36,7 +36,7 @@ struct AccountView: View {
                 }
                 .padding(.horizontal, 8)
             } else {
-                SignOutView(viewModel: viewModel)
+                DeleteAccountView(viewModel: viewModel)
             }
         }
         .onAppearAndActiveCheckUserValued(scenePhase)

--- a/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SignOutView: View {
+struct DeleteAccountView: View {
     @Environment(PlakeCoordinator.self) private var coordinator
     let viewModel: AccountViewModel
     

--- a/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
@@ -174,7 +174,7 @@ final class ClusterBubbleAnnotationView: MKAnnotationView {
         guard let clusterAnnotation = annotation as? MKClusterAnnotation else { return }
 
         let playlistAnnotations = clusterAnnotation.memberAnnotations.compactMap { $0 as? PlaylistAnnotation }
-        let playlists = playlistAnnotations.map { $0.playlist }
+        let playlists = playlistAnnotations.map { $0.playlist }.sorted { $0.generationTime > $1.generationTime}
 
         let count = playlists.count
         let clusterBubbleView = ClusterBubbleView(playlists: playlists, count: count)

--- a/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
@@ -91,7 +91,7 @@ struct MKMapViewWrapper: UIViewRepresentable {
         func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
             if let clusterAnnotation = view.annotation as? MKClusterAnnotation {
                 let playlistAnnotations = clusterAnnotation.memberAnnotations.compactMap { $0 as? PlaylistAnnotation }
-                let playlists = playlistAnnotations.map { $0.playlist }.sorted { $0.generationTime < $1.generationTime }
+                let playlists = playlistAnnotations.map { $0.playlist }.sorted { $0.generationTime > $1.generationTime }
 
                 Task { @MainActor in
                     let collectionPlaceViewModel = CollectionPlaceViewModel(playlists: playlists)

--- a/AGAMI/Sources/Presentation/View/Map/MapController.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MapController.swift
@@ -1,0 +1,69 @@
+//
+//  MapController.swift
+//  AGAMI
+//
+//  Created by yegang on 11/13/24.
+//
+
+import SwiftUI
+
+struct MapController: View {
+    @State var isShowingOtherPlake: Bool = false
+    @State var isReturningToCurrentLocation: Bool = false
+    @State var isFetchingVisibleRegionData: Bool = false
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            Spacer()
+            
+            VStack(alignment: .trailing, spacing: 12) {
+                Button {
+                    isShowingOtherPlake.toggle()
+                } label: {
+                    Circle()
+                        .frame(maxWidth: 44, maxHeight: 44)
+                        .foregroundStyle(isShowingOtherPlake ? Color(.pPrimary) : Color(.pWhite))
+                        .overlay(
+                            Text("My")
+                                .font(.pretendard(weight: .medium500, size: 16))
+                                .foregroundStyle(isShowingOtherPlake ? Color(.pWhite) : Color(.pPrimary))
+                        )
+                }
+                
+                Button {
+                    isReturningToCurrentLocation.toggle()
+                } label: {
+                    Circle()
+                        .frame(maxWidth: 44, maxHeight: 44)
+                        .foregroundStyle(Color(.pWhite))
+                        .overlay(
+                            Image(systemName: "scope")
+                                .resizable()
+                                .frame(maxWidth: 28, maxHeight: 28)
+                                .foregroundStyle(isReturningToCurrentLocation ? Color(.pPrimary) : Color(.pPrimary).opacity(0.3))
+                        )
+                }
+                
+                Button {
+                    isFetchingVisibleRegionData.toggle()
+                } label: {
+                    Circle()
+                        .frame(maxWidth: 44, maxHeight: 44)
+                        .foregroundStyle(Color(.pWhite))
+                        .overlay(
+                            Image(systemName: "arrow.counterclockwise")
+                                .resizable()
+                                .frame(maxWidth: 21, maxHeight: 24)
+                                .foregroundStyle(isFetchingVisibleRegionData ? Color(.pPrimary) : Color(.pPrimary).opacity(0.3))
+                        )
+                }
+                
+                Spacer()
+            }
+        }
+    }
+}
+
+#Preview {
+    MapController()
+}

--- a/AGAMI/Sources/Presentation/View/Map/MapView.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MapView.swift
@@ -13,12 +13,17 @@ struct MapView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
-        MKMapViewWrapper(viewModel: viewModel)
-            .onAppearAndActiveCheckUserValued(scenePhase)
-            .ignoresSafeArea()
-            .onAppear {
-                viewModel.fecthPlaylists()
-                viewModel.getCurrentLocation()
-            }
+        ZStack {
+            MKMapViewWrapper(viewModel: viewModel)
+            
+            MapController()
+                .padding(EdgeInsets(top: 62, leading: 0, bottom: 0, trailing: 24))
+        }
+        .onAppearAndActiveCheckUserValued(scenePhase)
+        .ignoresSafeArea()
+        .onAppear {
+            viewModel.fecthPlaylists()
+            viewModel.getCurrentLocation()
+        }
     }
 }


### PR DESCRIPTION
## ✅ Description
- 맵 뷰 디자인에 컨트롤러가 추가 돼서 디자인만 버튼으로 구현했습니다.

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- Button 을 사용해서 구현했습니다.
피그마 디자인을 보고 네이버 지도와 카카오 맵을 참고해보았습니다.

### 네이버 지도
- 새로고침, 현재 위치로 돌아가는 기능 둘 다 버튼 액션이 있는 버튼으로 구현 된 것으로 보임. 

### 카카오 맵
- 새로고침은 버튼으로, 현재 위치로 돌아가는 기능은 `onTapGesture` 으로 보임.

### 개인적인 생각
- 저희 앱에서는 `My` 버튼은 버튼으로 구현하고, 현재 위치로 돌아가는 기능과 새로고침 기능은 `onTapGesture` 으로 구현 하는 것도 괜찮다 생각 했으나 일단 셋 다 버튼으로 만들었습니다.

- 의견 있으시면 알려주세요. 특히 <h3>구리구리스</h3>

## 📸 Simulator
`Se3 기종`
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-11-13 at 23 16 13](https://github.com/user-attachments/assets/e1893bc0-976a-40f4-9237-bf8b71c4ad6f)

`16Pro 기종`
![Simulator Screenshot - iPhone 16 Pro - 2024-11-13 at 23 19 27](https://github.com/user-attachments/assets/81d9b88e-c44c-40f4-b9c8-26f199bd7fd4)

## 💡 Issue
- Resolved: #145 
