### PR TITLE
[#211] 회원 탈퇴 버그 수정

### DIFF
--- a/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
+++ b/AGAMI/Sources/Presentation/View/Account/DeleteAccountView.swift
@@ -33,6 +33,8 @@ struct DeleteAccountView: View {
                 }
                 
                 switch viewModel.deleteAccountProcess {
+                case .none:
+                    EmptyView()
                 case .inProgress:
                     Text("회원 탈퇴중입니다...")
                         .font(.notoSansKR(weight: .semiBold600, size: 22))

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -63,22 +63,22 @@ extension AccountViewModel {
     }
     
     func deleteAccount() {
-        guard let uid = FirebaseAuthService.currentUID else {
+        guard FirebaseAuthService.currentUID != nil else {
             dump("viewModel UID를 가져오는 데 실패했습니다.")
             return
         }
         
         Task {
             do {
-                try await deleteFirebaseData()
-                try await firebaseService.deleteUserInformationDocument(userID: uid) {
+                try await firebaseAuthService.deleteAccount {
+                    self.deleteAccountProcess = .inProgress
+                    try await self.deleteFirebaseData()
+                } changeProcessFinished: {
                     self.deleteAccountProcess = .finished
                 }
-                await firebaseAuthService.deleteAccount {
-                    self.deleteAccountProcess = .inProgress
-                }
             } catch {
-                dump("계정 삭제 중 오류 발생: \(error.localizedDescription)")
+                dump("계정 삭제 중 오류 발생 in accountviewmdoel: \(error.localizedDescription)")
+                self.deleteAccountProcess = .none
             }
         }
     }

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -63,7 +63,7 @@ extension AccountViewModel {
     }
     
     func deleteAccount() {
-        guard FirebaseAuthService.currentUID != nil else {
+        guard let uid = FirebaseAuthService.currentUID else {
             dump("viewModel UID를 가져오는 데 실패했습니다.")
             return
         }

--- a/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Account/AccountViewModel.swift
@@ -63,22 +63,20 @@ extension AccountViewModel {
     }
     
     func deleteAccount() {
-        guard let uid = FirebaseAuthService.currentUID else {
-            dump("viewModel UID를 가져오는 데 실패했습니다.")
-            return
-        }
-        
         Task {
             do {
-                try await firebaseAuthService.deleteAccount {
-                    self.deleteAccountProcess = .inProgress
-                    try await self.deleteFirebaseData()
-                } changeProcessFinished: {
-                    self.deleteAccountProcess = .finished
-                }
+                try firebaseAuthService.updateAuthProcessState()
+                let appleIDCedential = try await firebaseAuthService.appleAuthentication()
+                
+                self.deleteAccountProcess = .inProgress
+                try await self.deleteFirebaseData()
+                try await firebaseAuthService.handleAppleIDAuthentication(appleIDCredential: appleIDCedential)
+                
+                self.deleteAccountProcess = .finished
+                try await firebaseAuthService.deleteUserInfoWithDelay()
             } catch {
                 dump("계정 삭제 중 오류 발생 in accountviewmdoel: \(error.localizedDescription)")
-                self.deleteAccountProcess = .none
+                deleteAccountProcess = .none
             }
         }
     }

--- a/AGAMI/Sources/Service/Firebase/FirebaseAuthService.swift
+++ b/AGAMI/Sources/Service/Firebase/FirebaseAuthService.swift
@@ -137,7 +137,7 @@ final class FirebaseAuthService {
     }
 
     func deleteAccount(
-        changeProcessInProgress: @escaping () async throws -> Void,
+        changeProcessInProgress: () async throws -> Void,
         changeProcessFinished: @escaping () -> Void
     ) async throws {
         guard let user = user else { return }


### PR DESCRIPTION
## ✅ Description
- 페이스 아이디하는 중에 취소하면 정상적으로 원래 화면으로 돌다오도록
- 단계에 맞는 deleteAccountProcess 설정하여 view 정상적으로 나오도록 수정하였습니다. 

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 현재 FirebaseAuthService/ deleteAccount()가 비대하고, 2개의 클로저를 받고 있다는 점 등을 수정하고 싶습니다. viewModel과 service 관계 때문에 다른 방식이 생각이 안 났는데 방법이 있다면 피드백 부탁드립니다.
-  isUserValued가 수정되면(FirebaseAuthService 파일 185줄, FirebaseService().deleteUserInformationDocument) 바로 view가 signinView로 이동하게 되어, "회원탈퇴가 정상적으로 완료되었습니다."를 2초간 보여주기 위해 DispatchQueue를 사용하게 되었습니다. 혹시 다른 방식이 있다면 부탁드립니다.

## 📸 Simulator


## 💡 Issue
- Resolved: #211 
