### PR TITLE
[#235] 스티커 이미지 로고 추가 및 텍스트 색상 변경

### DIFF
--- a/AGAMI/Sources/Extensions/View+.swift
+++ b/AGAMI/Sources/Extensions/View+.swift
@@ -71,7 +71,7 @@ extension View {
     @ViewBuilder
     func instagramStickerStyle() -> some View {
         self
-            .padding(.horizontal, 64)
+            .padding(.horizontal, 48)
             .frame(width: 480, height: 640)
             .background(.black.opacity(0.2))
             .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/AGAMI/Sources/Presentation/View/Components/InstagramStickerView.swift
+++ b/AGAMI/Sources/Presentation/View/Components/InstagramStickerView.swift
@@ -61,7 +61,7 @@ private struct LogoRow: View {
             Spacer()
 
         }
-        .padding(EdgeInsets(top: 20, leading: -40, bottom: 24, trailing: -40))
+        .padding(EdgeInsets(top: 20, leading: -24, bottom: 24, trailing: -24))
     }
 }
 
@@ -77,6 +77,7 @@ private struct WithOneSong: View {
             LogoRow()
 
             StickerImage(uiImage: images.first)
+                .padding(.horizontal, 16)
 
             Spacer()
 
@@ -117,7 +118,7 @@ private struct WithTwoSongs: View {
                         .rotationEffect(.degrees(8.03))
                         .offset(x: 64, y: 96)
                 }
-                .padding(.horizontal, 40)
+                .padding(.horizontal, 56)
 
             }
             .aspectRatio(1, contentMode: .fit)
@@ -156,7 +157,7 @@ private struct WithMultipleSongs: View {
                 Group {
                     StickerImage(uiImage: images.first)
                         .rotationEffect(.degrees(0.86))
-                        .offset(x: 20, y: -40)
+                        .offset(x: 20, y: -20)
                     StickerImage(uiImage: images.dropLast(1).last)
                         .rotationEffect(.degrees(-12.4))
                         .offset(x: -48, y: 64)
@@ -164,7 +165,7 @@ private struct WithMultipleSongs: View {
                         .rotationEffect(.degrees(3.28))
                         .offset(x: 48, y: 96)
                 }
-                .padding(.horizontal, 40)
+                .padding(.horizontal, 56)
             }
             .aspectRatio(1, contentMode: .fit)
 

--- a/AGAMI/Sources/Presentation/View/Components/InstagramStickerView.swift
+++ b/AGAMI/Sources/Presentation/View/Components/InstagramStickerView.swift
@@ -37,15 +37,31 @@ private struct StickerImage: View {
                 Image(uiImage: image)
                     .resizable()
                     .aspectRatio(1, contentMode: .fit)
-                    .padding(.horizontal, 36)
+                    .padding(.horizontal, 32)
             } else {
                 Image(.sologPlaceholder)
                     .resizable()
                     .aspectRatio(1, contentMode: .fill)
                     .clipped()
-                    .padding(.horizontal, 36)
+                    .padding(.horizontal, 32)
             }
         }
+    }
+}
+
+private struct LogoRow: View {
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            Image(.sologListIcon)
+                .resizable()
+                .frame(width: 40, height: 40)
+            Text("소록")
+                .font(.sCoreDream(weight: .dream5, size: 26))
+                .foregroundStyle(Color(.sMain))
+            Spacer()
+
+        }
+        .padding(EdgeInsets(top: 20, leading: -40, bottom: 24, trailing: -40))
     }
 }
 
@@ -58,17 +74,19 @@ private struct WithOneSong: View {
         let address = playlist.streetAddress.split(separator: ",").first?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         VStack(alignment: .leading, spacing: 0) {
+            LogoRow()
+
             StickerImage(uiImage: images.first)
-                .padding(.top, 60)
 
             Spacer()
 
             Text("\(title ?? "")")
                 .font(.system(size: 24, weight: .medium))
-                .foregroundStyle(Color(.sLine))
+                .foregroundStyle(Color(.sBodyText))
+                .lineLimit(1)
                 .padding(.bottom, 6)
 
-            Text("'\(address ?? "")'에서\n수집한 기록입니다.")
+            Text("'\(address ?? "")'에서\n수집한 노래 기록입니다.")
                 .font(.system(size: 32, weight: .bold))
                 .foregroundStyle(Color(.sWhite))
                 .multilineTextAlignment(.leading)
@@ -88,6 +106,8 @@ private struct WithTwoSongs: View {
         let address = playlist.streetAddress.split(separator: ",").first?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         VStack(alignment: .leading, spacing: 0) {
+            LogoRow()
+
             ZStack {
                 Group {
                     StickerImage(uiImage: images.first)
@@ -97,20 +117,20 @@ private struct WithTwoSongs: View {
                         .rotationEffect(.degrees(8.03))
                         .offset(x: 64, y: 96)
                 }
-                .padding(.horizontal, 32)
+                .padding(.horizontal, 40)
 
             }
             .aspectRatio(1, contentMode: .fit)
-            .padding(.top, 70)
 
             Spacer()
 
             Text("\(title ?? "") 외 1곡")
                 .font(.system(size: 24, weight: .medium))
-                .foregroundStyle(Color(.sLine))
+                .foregroundStyle(Color(.sBodyText))
+                .lineLimit(1)
                 .padding(.bottom, 6)
 
-            Text("'\(address ?? "")'에서\n수집한 기록입니다.")
+            Text("'\(address ?? "")'에서\n수집한 노래 기록입니다.")
                 .font(.system(size: 32, weight: .bold))
                 .foregroundStyle(Color(.sWhite))
                 .multilineTextAlignment(.leading)
@@ -130,6 +150,8 @@ private struct WithMultipleSongs: View {
         let address = playlist.streetAddress.split(separator: ",").first?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         VStack(alignment: .leading, spacing: 0) {
+            LogoRow()
+
             ZStack {
                 Group {
                     StickerImage(uiImage: images.first)
@@ -142,19 +164,19 @@ private struct WithMultipleSongs: View {
                         .rotationEffect(.degrees(3.28))
                         .offset(x: 48, y: 96)
                 }
-                .padding(.horizontal, 32)
+                .padding(.horizontal, 40)
             }
             .aspectRatio(1, contentMode: .fit)
-            .padding(.top, 70)
 
             Spacer()
 
             Text("\(title ?? "") 외 \(playlist.songs.count - 1)곡")
                 .font(.system(size: 24, weight: .medium))
-                .foregroundStyle(Color(.sLine))
+                .foregroundStyle(Color(.sBodyText))
+                .lineLimit(1)
                 .padding(.bottom, 6)
 
-            Text("'\(address ?? "")'에서\n수집한 기록입니다.")
+            Text("'\(address ?? "")'에서\n수집한 노래 기록입니다.")
                 .font(.system(size: 32, weight: .bold))
                 .foregroundStyle(Color(.sWhite))
                 .multilineTextAlignment(.leading)

--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -35,7 +35,7 @@ struct PlakePlaylistView: View {
             if viewModel.presentationState.isLoading {
                 ProgressView()
             }
-            
+
             if viewModel.presentationState.isShowingSongDetailView {
                 SongDetailView(detailSong: viewModel.detailSong,
                                isLoading: viewModel.presentationState.isDetailViewLoading,


### PR DESCRIPTION
## ✅ Description
- 스티커 이미지 로고 추가 및 텍스트 색상 변경

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 스티커 이미지 로고 추가 및 텍스트 색상 변경 했습니다

## 📸 Simulator
<img src="https://github.com/user-attachments/assets/d9e13d17-8ae7-4df8-857d-064d0353d27c" width="200">
<img src="https://github.com/user-attachments/assets/1ffeca78-1873-44f5-a9ab-e7ecebf8cf18" width="200">
<img src="https://github.com/user-attachments/assets/32f6661c-3deb-4c2e-b179-dab77195b759" width="200">

## 💡 Issue
- Resolved: #235
