### PR TITLE
[#241] 타이틀 및 아티스트가 한줄 이상될 때 생략 반영

### DIFF
--- a/AGAMI/Sources/Presentation/View/Components/PlaylistRow.swift
+++ b/AGAMI/Sources/Presentation/View/Components/PlaylistRow.swift
@@ -46,6 +46,10 @@ struct PlaylistRow: View {
                     .kerning(-0.3)
                     .foregroundStyle(Color(.sBodyText))
             }
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.trailing, 30)
+            
             Spacer()
         }
         .background(isHighlighted ? Color(.sListBack) : .clear)


### PR DESCRIPTION
## ✅ Description
- 타이틀 및 아티스트가 한줄 이상될 때 생략 반영 했습니다. 

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
-

## 📸 Simulator
| 수정 전 | 수정 후 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/9764f8af-286e-4bed-97d9-5760e580e1dd" width=300> | <img src="https://github.com/user-attachments/assets/f376909e-2a15-4c54-9b59-11c51b464cee" width=300> |

## 💡 Issue
- Resolved: #241 
