### PR TITLE
[#248] 쇼케이스(2.2 릴리즈) 전 버그 수정

### DIFF
--- a/AGAMI/Sources/Coordinator/BaseCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/BaseCoordinator.swift
@@ -20,7 +20,9 @@ class BaseCoordinator<Route: Hashable, Sheet: Identifiable, FullScreenCover: Ide
     }
 
     func pop() {
-        path.removeLast()
+        if !path.isEmpty {
+            path.removeLast()
+        }
     }
 
     func popToRoot() {

--- a/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
+++ b/AGAMI/Sources/Coordinator/PlakeCoordinator.swift
@@ -11,20 +11,14 @@ import SwiftUI
 enum PlakeRoute: Hashable {
     case listView
     case playlistView(viewModel: PlakePlaylistViewModel)
-
     case searchWritingView
-    case cameraView(viewModelContainer: CoordinatorViewModelContainer)
-
     case placeListView(viewModel: CollectionPlaceViewModel)
 
     var id: String {
         switch self {
         case .listView: return "listView"
         case .playlistView: return "playlistView"
-
         case .searchWritingView: return "searchWritingView"
-        case .cameraView: return "cameraView"
-
         case .placeListView: return "placeListView"
         }
     }
@@ -68,10 +62,12 @@ enum PlakeFullScreenCover: Hashable, Identifiable {
     var id: String {
         switch self {
         case .imageViewerView: return "imageViewerView"
+        case .cameraView: return "cameraView"
         }
     }
     
     case imageViewerView(urlString: String)
+    case cameraView(viewModelContainer: CoordinatorViewModelContainer)
 }
 
 final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullScreenCover> {
@@ -84,8 +80,6 @@ final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullS
             PlakePlaylistView(viewModel: viewModel)
         case .searchWritingView:
             SearchWritingView()
-        case let .cameraView(viewModelContainer):
-            CameraView(viewModel: .init(container: viewModelContainer))
         case let .placeListView(viewModel):
             CollectionPlaceView(viewModel: viewModel)
         }
@@ -117,6 +111,8 @@ final class PlakeCoordinator: BaseCoordinator<PlakeRoute, PlakeSheet, PlakeFullS
         switch cover {
         case let .imageViewerView(urlString):
             ImageViewerView(urlString: urlString)
+        case let .cameraView(viewModelContainer):
+            CameraView(viewModel: .init(container: viewModelContainer))
         }
     }
 }

--- a/AGAMI/Sources/Presentation/View/Camera/CameraView.swift
+++ b/AGAMI/Sources/Presentation/View/Camera/CameraView.swift
@@ -16,23 +16,24 @@ struct CameraView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            VStack(spacing: 0) {
-                Spacer()
+        NavigationStack {
+            GeometryReader { geometry in
+                VStack(spacing: 0) {
+                    Spacer()
 
-                PhotoPreview(viewModel: viewModel, size: geometry.size)
+                    PhotoPreview(viewModel: viewModel, size: geometry.size)
 
-                ConfigureButtons(viewModel: viewModel)
-            }
-            .ignoresSafeArea()
-            .background(Color(.sBlack))
-            .navigationBarBackButtonHidden()
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    ToolbarLeadingItem(viewModel: viewModel)
+                    ConfigureButtons(viewModel: viewModel)
+                }
+                .ignoresSafeArea()
+                .background(Color(.sBlack))
+                .navigationBarBackButtonHidden()
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        ToolbarLeadingItem(viewModel: viewModel)
+                    }
                 }
             }
-            .disablePopGesture()
         }
     }
 }
@@ -174,7 +175,7 @@ private struct SavePhotoButton: View {
         Button {
             viewModel.savePhoto()
             viewModel.playSimpleHaptic()
-            coordinator.pop()
+            coordinator.dismissFullScreenCover()
         } label: {
             Image(.cameraButton)
                 .resizable()
@@ -189,7 +190,7 @@ private struct ToolbarLeadingItem: View {
 
     var body: some View {
         Button {
-            coordinator.pop()
+            coordinator.dismissFullScreenCover()
         } label: {
             if viewModel.photoUIImage == nil {
                 Image(systemName: "chevron.backward")

--- a/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MKMapViewWrapper.swift
@@ -11,7 +11,8 @@ import Kingfisher
 
 // MARK: - MKMapView 래퍼
 struct MKMapViewWrapper: UIViewRepresentable {
-    @Environment(MapCoordinator.self) var coordinator
+    @Environment(PlakeCoordinator.self) private var plakeCoordinator
+    @Environment(MapCoordinator.self) private var mapCoordinator
     var viewModel: MapViewModel
 
     func makeUIView(context: Context) -> MKMapView {
@@ -99,7 +100,7 @@ struct MKMapViewWrapper: UIViewRepresentable {
                     HapticService.shared.playSimpleHaptic()
                     clusterView.setSelected(true, animated: true)
                     let collectionPlaceViewModel = CollectionPlaceViewModel(playlists: playlists)
-                    self.parent.coordinator.push(route: .collectionPlaceView(viewModel: collectionPlaceViewModel))
+                    self.parent.mapCoordinator.push(route: .collectionPlaceView(viewModel: collectionPlaceViewModel))
                 }
 
             } else if let playlistAnnotation = view.annotation as? PlaylistAnnotation,
@@ -110,8 +111,11 @@ struct MKMapViewWrapper: UIViewRepresentable {
                 Task { @MainActor in
                     HapticService.shared.playSimpleHaptic()
                     bubbleView.setSelected(true, animated: true)
-                    let collectionPlaceViewModel = CollectionPlaceViewModel(playlists: [playlist])
-                    self.parent.coordinator.push(route: .collectionPlaceView(viewModel: collectionPlaceViewModel))
+                    self.parent.plakeCoordinator.dismissSheet()
+
+                    try await Task.sleep(for: .milliseconds(300))
+                    let playlistViewModel = PlakePlaylistViewModel(playlist: playlist)
+                    self.parent.plakeCoordinator.push(route: .playlistView(viewModel: playlistViewModel))
                 }
 
             }

--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -412,9 +412,7 @@ private struct PhotoConfirmationDialogActions: View {
     
     var body: some View {
         Button("카메라") {
-            coordinator.push(route: .cameraView(
-                viewModelContainer: .plakePlaylist(viewModel: viewModel)
-            ))
+            coordinator.presentFullScreenCover(.cameraView(viewModelContainer: .plakePlaylist(viewModel: viewModel)))
         }
         Button("앨범에서 가져오기") {
             viewModel.presentationState.isShowingPicker = true

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -361,7 +361,7 @@ private struct PhotoConfirmationDialogActions: View {
     
     var body: some View {
         Button("사진 찍기") {
-            coordinator.push(route: .cameraView(viewModelContainer: .searchWriting(viewModel: viewModel)))
+            coordinator.presentFullScreenCover(.cameraView(viewModelContainer: .searchWriting(viewModel: viewModel)))
         }
         Button("사진 보관함 열기") {
             viewModel.showPhotoPicker = true

--- a/AGAMI/Sources/Presentation/ViewModel/Search/SearchWritingViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Search/SearchWritingViewModel.swift
@@ -151,18 +151,16 @@ final class SearchWritingViewModel {
     func processPhoto(image: UIImage) {
         isPhotoLoading = true
         Task(priority: .userInitiated) {
-            if let resizedAndCroppedImage = image.resizedAndCropped(to: CGSize(width: 1024, height: 1024))?.cropToFiveByFour() {
-                let compressedImageData = resizedAndCroppedImage.jpegData(compressionQuality: 0.6)
+            guard let resizedAndCroppedImage = image.resizedAndCropped(to: CGSize(width: 1280, height: 1024))
+            else {
+                await MainActor.run { isPhotoLoading = false }
+                return
+            }
 
-                await MainActor.run {
-                    self.playlist.photoData = compressedImageData
-                    self.persistenceService.updatePlaylist()
-                    self.isPhotoLoading = false
-                }
-            } else {
-                await MainActor.run {
-                    self.isPhotoLoading = false
-                }
+            await MainActor.run {
+                self.playlist.photoData = resizedAndCroppedImage.jpegData(compressionQuality: 0.6)
+                self.persistenceService.updatePlaylist()
+                self.isPhotoLoading = false
             }
         }
     }

--- a/AGAMI/Sources/Service/Camera/CameraService.swift
+++ b/AGAMI/Sources/Service/Camera/CameraService.swift
@@ -156,7 +156,10 @@ final class CameraService: NSObject {
 }
 
 extension CameraService: AVCapturePhotoCaptureDelegate {
-    func photoOutput(_ output: AVCapturePhotoOutput, willBeginCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings) { }
+    func photoOutput(_ output: AVCapturePhotoOutput, willBeginCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+        // 카메라 무음
+        AudioServicesDisposeSystemSoundID(1108)
+    }
     
     func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
         // 카메라 무음


### PR DESCRIPTION
## ✅ Description
- 쇼케이스(2.2 릴리즈) 전 버그 수정

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- `processPhoto()` 메소드 사진 해상도 1280*1024로 수정하여 정방형으로 리사이징 후 크롭되어 가로 영역이 사라지던 버그 수정했습니다
- 기존 카메라 버튼 연타 시 앱이 크래시되는 버그가 있었습니다
    - `coordinator.pop()`이 여러 번 실행되어 비어 있는 `NavigationPath`의 `removeLast`를 호출 시 터지는 것을 발견했습니다
    - 버튼 disable 트리거 변수를 두어 해결하려 했지만, 버튼 액션이 여러번 실행되는 현상을 막을 수 없었습니다
    - 버그를 방지하기 위해, 또한 UX적으로도 `fullscreencover`로의 전환이 맞다는 생각이 들어 수정했습니다
        - 추가적으로, `BaseCoordinator.pop()` 메소드에 Empty Collection pop 방지 로직 넣어 두었습니다
- iOS 17 버전에서 오늘 발견한 이슈 외에도 버그가 상당히 많습니다.. 별도의 이슈 단위로 다 뜯어 고쳐야 할 듯 싶습니다

## 📸 Simulator
<div align="center">
<img src="https://github.com/user-attachments/assets/9c75533e-2ded-4d16-8314-f81ac390475f" width="200">
<img src="https://github.com/user-attachments/assets/06cb121a-aba5-4d52-9a62-eb298264b186" width="200">
</div>

## 💡 Issue
- Resolved: #248
