### PR TITLE
[#252] iOS17 SearchWritingView 먹통 버그, modelContext.save() 크래시 버그 수정

### DIFF
--- a/AGAMI/Sources/Presentation/View/Map/MapView.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MapView.swift
@@ -23,7 +23,7 @@ struct MapView: View {
             MKMapViewWrapper(viewModel: viewModel)
                 .ignoresSafeArea(edges: .bottom)
                 .onAppearAndActiveCheckUserValued(scenePhase)
-                .onAppear(perform: viewModel.initializeView)
+                .onAppear(perform: viewModel.requestCurrentLocation)
                 .navigationTitle("기록 지도")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -52,7 +52,7 @@ struct SearchWritingView: View {
             }
             
         }
-        .task { await viewModel.fetchCurrentLocation() }
+        .onAppear(perform: viewModel.requestCurrentLocation)
         .ignoresSafeArea(edges: .bottom)
         .onAppearAndActiveCheckUserValued(scenePhase)
         .onTapGesture(perform: hideKeyboard)

--- a/AGAMI/Sources/Presentation/ViewModel/Map/MapViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Map/MapViewModel.swift
@@ -11,12 +11,8 @@ import MapKit
 @Observable
 final class MapViewModel {
     private let locationService = LocationService.shared
-    
+
     var currentLocationCoordinate2D: CLLocationCoordinate2D?
-    var isLoaded: Bool = false
-
-    var goToDetail: Bool = false
-
     let playlists: [PlaylistModel]
 
     init(playlists: [PlaylistModel]) {

--- a/AGAMI/Sources/Presentation/ViewModel/Map/MapViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Map/MapViewModel.swift
@@ -13,9 +13,6 @@ final class MapViewModel {
     private let locationService = LocationService.shared
     
     var currentLocationCoordinate2D: CLLocationCoordinate2D?
-    var currentlatitude: Double?
-    var currentlongitude: Double?
-    var currentStreetAddress: String?
     var isLoaded: Bool = false
 
     var goToDetail: Bool = false
@@ -24,35 +21,16 @@ final class MapViewModel {
 
     init(playlists: [PlaylistModel]) {
         self.playlists = playlists
+        locationService.delegate = self
     }
 
-    func initializeView() {
-        Task {
-            await fetchCurrentLocation()
-        }
-    }
-    
-    func fetchCurrentLocation() async {
-        do {
-            let location = try await locationService.requestCurrentLocation()
-            currentLocationCoordinate2D = location.coordinate
-            currentlatitude = location.coordinate.latitude
-            currentlongitude = location.coordinate.longitude
-            await fetchCurrentStreetAddress()
-        } catch {
-            dump("현재 위치를 가져오는 데 실패했습니다: \(error)")
-        }
-    }
-
-    func fetchCurrentStreetAddress() async {
-        if let address = await locationService.coordinateToStreetAddress() {
-            currentStreetAddress = address
-        }
+    func requestCurrentLocation() {
+        locationService.requestCurrentLocation()
     }
 }
 
 extension MapViewModel: LocationServiceDelegate {
-    func locationService(_ service: LocationService, didUpdate location: [CLLocation]) {
-        isLoaded = true
+    func locationService(didUpdate location: CLLocation) {
+        currentLocationCoordinate2D = location.coordinate
     }
 }

--- a/AGAMI/Sources/Service/Persistence/PersistenceService.swift
+++ b/AGAMI/Sources/Service/Persistence/PersistenceService.swift
@@ -81,8 +81,12 @@ final class PersistenceService {
     func deleteAllPlaylists() {
         let playlists = fetchPlaylists()
         for playlist in playlists {
+            for song in playlist.swiftDataSongs {
+                modelContext.delete(song)
+            }
             modelContext.delete(playlist)
         }
+        updatePlaylist()
     }
     
     func appendSong(from mediaItem: SHMediaItem) {


### PR DESCRIPTION
## ✅ Description
- iOS17 SearchWritingView 먹통 버그 수정

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 기존 iOS17에서 `SearchWritingView`가 먹통이 되는 이슈가 있었습니다
    - `.task { await viewModel.fetchCurrentLocation() }` 뷰 모디파이어 제거시 정상 작동하는 것을 확인했습니다
    - `fetchCurrentLocation` 리턴 밸류 내부에서 `continuation.resume()`을 호출해 주지 않아 await를 영원히 기다리고 있는 교착 상태에 빠져 있는 것을 확인했습니다
    - 로직 수정 및 미사용 메소드, 프로퍼티 제거했습니다
 - `SearchWritingView`에서 뒤로가기 버튼을 누르면 간헐적으로 앱이 크래시되는 버그가 있었습니다
     - iOS 18에서 `SwiftData` `@Relation` 프로퍼티를 가지고 있는 모델을 제거한 후 `modelContext.save()`를 명시적으로 호출하면 앱이 크래시되는 버그가 있어 `modelContext.save()`를 호출하지 않도록 수정했었는데, 그렇다 보니 간혹 이전 `SwiftData` 모델을 제거한 후 context 저장이 이루어지지 않아 다시 생성할 때 `PersistentIdentifier`가 중복되면서 앱이 크래시되는 것을 확인했습니다
     - 기존 `PersistenceService.deleteAllPlaylist()`를 자식 프로퍼티인 `SwiftDataSongModel`을 모두 제거 후 `SwiftDataPlaylistModel`을 제거하도록, 모두 지우면 `modelContext.save()`를 명시적으로 호출하도록 수정했습니다
     - iOS17 / 18에서 정상 작동 확인했습니다

## 📸 Simulator
https://github.com/user-attachments/assets/38e4b533-f3df-476b-8bc4-d3f016636703

## 💡 Issue
- Resolved: #252
