### PR TITLE
[#258] iOS17 네비게이션 바 expand, hidden 버그 수정

### DIFF
--- a/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Plake/PlakePlaylistView.swift
@@ -43,7 +43,6 @@ struct PlakePlaylistView: View {
                 .task { await viewModel.fetchAdditionalDetails() }
             }
         }
-        .background(viewModel.presentationState.isEditing ? Color(.sTitleText) : Color(.sMain))
         .task { await viewModel.refreshPlaylist() }
         .onAppearAndActiveCheckUserValued(scenePhase)
         .toolbar {
@@ -54,9 +53,12 @@ struct PlakePlaylistView: View {
                 TopBarTrailingItems(viewModel: viewModel)
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarVisibilityForVersion(.visible, for: .navigationBar)
         .toolbarBackground(viewModel.presentationState.isEditing ? Color(.sTitleText) : Color(.sMain), for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .navigationBarBackButtonHidden()
+        .background(viewModel.presentationState.isEditing ? Color(.sTitleText) : Color(.sMain))
         .onTapGesture(perform: hideKeyboard)
         .refreshable { await viewModel.refreshPlaylist() }
         .confirmationDialog("", isPresented: $viewModel.presentationState.isPhotoDialogPresented) {
@@ -120,7 +122,8 @@ private struct ListView: View {
             }
             .listStyle(.plain)
             .scrollIndicators(.hidden)
-            
+            .safeAreaInset(edge: .top, spacing: 0) { Color.clear.frame(height: 0) }
+
             if viewModel.presentationState.isEditing {
                 BottomConfigurationBar(viewModel: viewModel)
             }

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -52,6 +52,7 @@ struct SearchWritingView: View {
             }
             
         }
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear(perform: viewModel.requestCurrentLocation)
         .ignoresSafeArea(edges: .bottom)
         .onAppearAndActiveCheckUserValued(scenePhase)


### PR DESCRIPTION
## ✅ Description
- iOS17 네비게이션 바 expand, hidden 버그 수정

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- iOS17 네비게이션 바 expand, hidden 버그 수정했습니다
    - `.navigationBarTitleDisplayMode(.inline)`을 명시해 주니 iOS17에서 네비게이션 바가 확장되던 버그가 수정되었습니다
    
- 네비게이션 바 visibility를 `.visible`로 명시해 주니 시트 dismiss 후 path에 route 추가 시 네비게이션 바가 표시되지 않던 버그가 수정되었습니다
  ```swift
    @ViewBuilder
    func toolbarVisibilityForVersion(_ visibility: Visibility, for placement: ToolbarPlacement) -> some View {
        if #available(iOS 18.0, *) {
            self.toolbarVisibility(visibility, for: placement)
        } else {
            self.toolbar(visibility, for: placement)
        }
    }    
   ```

## 📸 Simulator


## 💡 Issue
- Resolved: #258
