### PR TITLE
[#262] 커스텀 델리게이트 패턴 -> Swift Conurrency | 곡 디테일 정보 fetch 로직 서비스 레이어로 분리

### DIFF
--- a/AGAMI/Sources/Error/ShazamError.swift
+++ b/AGAMI/Sources/Error/ShazamError.swift
@@ -1,0 +1,15 @@
+//
+//  ShazamError.swift
+//  AGAMI
+//
+//  Created by 박현수 on 12/9/24.
+//
+
+import Foundation
+
+enum ShazamError: Error {
+    case isRunning
+    case didNotFindMatch
+    case didFail
+    case cancelled
+}

--- a/AGAMI/Sources/Helpers/DetailSong.swift
+++ b/AGAMI/Sources/Helpers/DetailSong.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct DetailSong {
-    var songTItle: String?
+    var songTitle: String?
     var artist: String?
     var albumCoverURL: String?
     var albumTitle: String?

--- a/AGAMI/Sources/Presentation/View/Components/SongDetailView.swift
+++ b/AGAMI/Sources/Presentation/View/Components/SongDetailView.swift
@@ -53,7 +53,7 @@ struct SongDetailView: View {
                             .padding(.top, 33)
                     }
                     
-                    Text(detailSong?.songTItle ?? "")
+                    Text(detailSong?.songTitle ?? "")
                         .font(.notoSansKR(weight: .bold700, size: 24))
                         .padding(.horizontal, 18)
                         .padding(.top, 18)

--- a/AGAMI/Sources/Presentation/View/Map/MapView.swift
+++ b/AGAMI/Sources/Presentation/View/Map/MapView.swift
@@ -21,9 +21,9 @@ struct MapView: View {
     var body: some View {
         NavigationStack(path: $mapCoord.path) {
             MKMapViewWrapper(viewModel: viewModel)
-                .ignoresSafeArea(edges: .bottom)
                 .onAppearAndActiveCheckUserValued(scenePhase)
-                .onAppear(perform: viewModel.requestCurrentLocation)
+                .task { await viewModel.requestCurrentLocation() }
+                .ignoresSafeArea(edges: .bottom)
                 .navigationTitle("기록 지도")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -53,7 +53,7 @@ struct SearchWritingView: View {
             
         }
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear(perform: viewModel.requestCurrentLocation)
+        .task { await viewModel.requestCurrentLocation() } 
         .ignoresSafeArea(edges: .bottom)
         .onAppearAndActiveCheckUserValued(scenePhase)
         .onTapGesture(perform: hideKeyboard)

--- a/AGAMI/Sources/Presentation/ViewModel/Map/MapViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Map/MapViewModel.swift
@@ -17,16 +17,9 @@ final class MapViewModel {
 
     init(playlists: [PlaylistModel]) {
         self.playlists = playlists
-        locationService.delegate = self
     }
 
-    func requestCurrentLocation() {
-        locationService.requestCurrentLocation()
-    }
-}
-
-extension MapViewModel: LocationServiceDelegate {
-    func locationService(didUpdate location: CLLocation) {
-        currentLocationCoordinate2D = location.coordinate
+    func requestCurrentLocation() async {
+        currentLocationCoordinate2D = try? await locationService.requestCurrentLocation()
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakeListViewModel.swift
@@ -12,7 +12,7 @@ import FirebaseFirestore
 @Observable
 final class PlakeListViewModel {
     private let firebaseService = FirebaseService()
-    private let musicService = MusicService()
+    private let musicService = MusicService.shared
 
     var isFetching: Bool = false
     var isSearching: Bool = false

--- a/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Plake/PlakePlaylistViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftUI
 import PhotosUI
-import MusicKit
 import ShazamKit
 
 struct PlaylistPresentationState {
@@ -39,9 +38,9 @@ final class PlakePlaylistViewModel: Hashable {
     private var initialPlaylist: PlaylistModel
     
     private let shazamService = ShazamService.shared
-    private let firebaseService: FirebaseService = FirebaseService()
-    private let musicService: MusicService = MusicService()
-    
+    private let firebaseService = FirebaseService()
+    private let musicService = MusicService.shared
+
     var exportingState: ExportingState = .none
     var presentationState: PlaylistPresentationState = .init()
     
@@ -349,7 +348,7 @@ final class PlakePlaylistViewModel: Hashable {
         var pasteboardItems: [String: Any] = [:]
         if let stickerImageData = await stickerImage.asUIImage(size: .init(width: 480, height: 800)) {
             pasteboardItems["com.instagram.sharedSticker.stickerImage"] = stickerImageData
-            
+
             if let backgroundImageData = backgroundImage?.jpegData(compressionQuality: 0.5) {
                 pasteboardItems["com.instagram.sharedSticker.backgroundImage"] = backgroundImageData
             }

--- a/AGAMI/Sources/Presentation/ViewModel/Search/SearchWritingViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Search/SearchWritingViewModel.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import PhotosUI
-import MusicKit
 
 @Observable
 final class SearchWritingViewModel {

--- a/AGAMI/Sources/Presentation/ViewModel/Search/SearchWritingViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Search/SearchWritingViewModel.swift
@@ -179,7 +179,7 @@ final class SearchWritingViewModel {
             }
             
             var detailSong = DetailSong()
-            detailSong.songTItle = selectedSong?.title
+            detailSong.songTitle = selectedSong?.title
             detailSong.artist = selectedSong?.artist
             detailSong.albumCoverURL = selectedSong?.albumCoverURL
             detailSong.albumTitle = song.albumTitle

--- a/AGAMI/Sources/Service/Export/MusicService.swift
+++ b/AGAMI/Sources/Service/Export/MusicService.swift
@@ -11,7 +11,10 @@ import MusicKit
 final class MusicService {
     private var playlist: Playlist?
     private var songs: [Song] = []
-    
+
+    static let shared = MusicService()
+    private init() { }
+
     func requestAuthorization() async throws {
         let status = MusicAuthorization.currentStatus
         switch status {

--- a/AGAMI/Sources/Service/Export/MusicService.swift
+++ b/AGAMI/Sources/Service/Export/MusicService.swift
@@ -71,7 +71,18 @@ final class MusicService {
         
         return song
     }
-    
+
+    func fetchSongInfoByID(_ songId: String) async -> Song? {
+        let status = await MusicAuthorization.request()
+        guard status == .authorized else { return nil }
+        let request = MusicCatalogResourceRequest<Song>(matching: \.id,
+                                                        equalTo: MusicItemID(songId))
+        guard let response = try? await request.response(),
+              let song = response.items.first
+        else { return nil }
+        return song
+    }
+
     func addSongToSongs(song: Song) {
         songs.append(song)
     }

--- a/AGAMI/Sources/Service/Shazam/ShazamService.swift
+++ b/AGAMI/Sources/Service/Shazam/ShazamService.swift
@@ -8,19 +8,11 @@ import Foundation
 import ShazamKit
 import AVKit
 
-protocol ShazamServiceDelegate: AnyObject {
-    @MainActor func shazamService(_ service: ShazamService, didFind match: SHMatch)
-    @MainActor func shazamService(_ service: ShazamService, didNotFindMatchFor signature: SHSignature, error: (any Error)?)
-    @MainActor func shazamService(_ service: ShazamService, didFailWithError error: Error)
-}
-
 final class ShazamService: NSObject {
-    weak var delegate: ShazamServiceDelegate?
-
     private let session = SHSession()
     private let audioEngine = AVAudioEngine()
-    private var timer: Timer?
-    
+    private var shazamContinuation: CheckedContinuation<SHMatch, Error>?
+
     static let shared: ShazamService = .init()
 
     override init() {
@@ -28,41 +20,41 @@ final class ShazamService: NSObject {
         session.delegate = self
     }
 
-    func startRecognition() {
-        dump(#function)
-        do {
+    func startRecognition() async throws -> SHMatch {
+        return try await withCheckedThrowingContinuation { continuation in
+            shazamContinuation = continuation
             if audioEngine.isRunning {
                 stopRecognition()
+                continuation.resume(throwing: ShazamError.isRunning)
                 return
             }
-
-            try prepareAudioRecording()
-            generateSignature()
-            try startAudioRecording()
-            startTimer()
-        } catch {
-            Task { @MainActor in
-                self.delegate?.shazamService(self, didFailWithError: error)
+            do {
+                try prepareAudioRecording()
+                generateSignature()
+                try startAudioRecording()
+            } catch {
+                continuation.resume(throwing: ShazamError.didFail)
+                return
             }
         }
     }
 
     func stopRecognition() {
-        dump(#function)
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: .zero)
-        stopTimer()
+        if let continuation = shazamContinuation {
+            shazamContinuation = nil
+            continuation.resume(throwing: ShazamError.cancelled)
+        }
     }
 
     private func prepareAudioRecording() throws {
-        dump(#function)
         let audioSession = AVAudioSession.sharedInstance()
         try audioSession.setCategory(.record)
         try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
     }
 
     private func generateSignature() {
-        dump(#function)
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: .zero)
 
@@ -72,45 +64,32 @@ final class ShazamService: NSObject {
     }
 
     private func startAudioRecording() throws {
-        dump(#function)
         try audioEngine.start()
-    }
-
-    private func startTimer() {
-        dump(#function)
-        guard timer == nil else { return } // 타이머 중복 생성 방지
-        timer = Timer.scheduledTimer(withTimeInterval: 20, repeats: true) { [weak self] _ in
-            dump("20초 경과 샤잠 종료")
-            self?.stopRecognition()
-        }
-    }
-
-    private func stopTimer() {
-        dump(#function)
-        timer?.invalidate()
-        timer = nil
     }
 }
 
 extension ShazamService: SHSessionDelegate {
     func session(_ session: SHSession, didFind match: SHMatch) {
         Task { @MainActor in
+            shazamContinuation?.resume(returning: match)
+            shazamContinuation = nil
             stopRecognition()
-            self.delegate?.shazamService(self, didFind: match)
         }
     }
 
     func session(_ session: SHSession, didNotFindMatchFor signature: SHSignature, error: (any Error)?) {
         Task { @MainActor in
+            shazamContinuation?.resume(throwing: ShazamError.didNotFindMatch)
+            shazamContinuation = nil
             stopRecognition()
-            self.delegate?.shazamService(self, didNotFindMatchFor: signature, error: error)
         }
     }
 
     func session(_ session: SHSession, didFailWithError error: Error) {
         Task { @MainActor in
+            shazamContinuation?.resume(throwing: ShazamError.didFail)
+            shazamContinuation = nil
             stopRecognition()
-            self.delegate?.shazamService(self, didFailWithError: error)
         }
     }
 }


### PR DESCRIPTION
## ✅ Description
- 커스텀 델리게이트 패턴 -> Swift Conurrency | 곡 디테일 정보 fetch 로직 서비스 레이어로 분리

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- `CheckedContinuation`을 이용해 기존 델리게이트 패턴을 이용해 데이터를 전달하던 로직을 개선했습니다
- 곡 디테일 정보를 fetch하는 로직을 서비스 레이어로 분리했습니다
- `MusicService` 인스턴스를 여러 곳에서 생성하고 있어서, 싱글톤 패턴으로 변경했습니다

## 💡 Issue
- Resolved: #262
