### PR TITLE
[#274] Spotify 토큰 갱신 로직 추가

### DIFF
--- a/AGAMI/Sources/Presentation/View/App/AppContentView.swift
+++ b/AGAMI/Sources/Presentation/View/App/AppContentView.swift
@@ -11,7 +11,9 @@ struct AppContentView: View {
     @AppStorage("isSignedIn") var isSignedIn: Bool = false
     @State private var sologCoordinator: SologCoordinator = .init()
     @State private var listCellPlaceholder: ListCellPlaceholderModel = ListCellPlaceholderModel()
-    
+
+    init() { initializeSpotifyService() }
+
     var body: some View {
         if isSignedIn {
             NavigationStack(path: $sologCoordinator.path) {
@@ -29,7 +31,6 @@ struct AppContentView: View {
             }
             .environment(listCellPlaceholder)
             .environment(sologCoordinator)
-            .onAppear(perform: initializeSpotifyService)
 
         } else {
             SignInView()
@@ -37,12 +38,12 @@ struct AppContentView: View {
     }
 
     private func handleURL(_ url: URL) {
-        if let redirectURL = Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URL") as? String,
-           let decodedRedirectURL = redirectURL.removingPercentEncoding {
-            if url.absoluteString.contains(decodedRedirectURL) {
-                SpotifyService.shared.handleURL(url)
-            }
-        }
+        guard let redirectURL = Bundle.main.object(forInfoDictionaryKey: "REDIRECT_URL") as? String,
+              let decodedRedirectURL = redirectURL.removingPercentEncoding,
+              url.absoluteString.contains(decodedRedirectURL)
+        else { return }
+        
+        SpotifyService.shared.handleURL(url)
     }
 
     private func initializeSpotifyService() {

--- a/AGAMI/Sources/Presentation/View/Solog/SologListView.swift
+++ b/AGAMI/Sources/Presentation/View/Solog/SologListView.swift
@@ -400,8 +400,6 @@ private struct ContextMenuItems: View {
             viewModel.exportPlaylistToSpotify(playlist: playlist) { result in
                 switch result {
                 case .success(let url):
-                    dump("ContextMenuItems")
-                    dump(url)
                     openURL(url)
                 case .failure(let err):
                     dump(err.localizedDescription)

--- a/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
@@ -31,9 +31,7 @@ struct SologPlaylistView: View {
                 EmptyView()
             }
 
-            if viewModel.presentationState.isLoading {
-                ProgressView()
-            }
+            if viewModel.presentationState.isLoading { ProgressView() }
 
             if viewModel.presentationState.isShowingSongDetailView {
                 SongDetailView(detailSong: viewModel.detailSong,


### PR DESCRIPTION
## ✅ Description
- Spotify 토큰 갱신 로직 추가

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 기존 `SpotifyService`에 토큰 갱신 로직이 들어가있지 않아 `AccessToken` 만료 기한인 1시간마다 다시 로그인을 해야 했습니다
- `RefreshToken`을 이용한 토큰 갱신 로직 추가했습니다

## 💡 Issue
- Resolved: #274
