### PR TITLE
[#278] `SpotifyService` escaping closure -> Swift Concurrency 리팩토링

### DIFF
--- a/AGAMI/Sources/Extensions/Publisher+.swift
+++ b/AGAMI/Sources/Extensions/Publisher+.swift
@@ -1,0 +1,32 @@
+//
+//  Publisher+.swift
+//  AGAMI
+//
+//  Created by 박현수 on 12/28/24.
+//
+
+import Combine
+
+extension Publisher {
+    /// Publisher의 single output을 async/await로 기다립니다.
+    func asyncSingleOutput() async throws -> Output {
+        try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = self.sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        break
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    }
+                    cancellable?.cancel()
+                },
+                receiveValue: { value in
+                    continuation.resume(returning: value)
+                    cancellable?.cancel()
+                }
+            )
+        }
+    }
+}

--- a/AGAMI/Sources/Extensions/Publisher+.swift
+++ b/AGAMI/Sources/Extensions/Publisher+.swift
@@ -12,21 +12,19 @@ extension Publisher {
     func asyncSingleOutput() async throws -> Output {
         try await withCheckedThrowingContinuation { continuation in
             var cancellable: AnyCancellable?
-            cancellable = self.sink(
-                receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        break
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-                    }
-                    cancellable?.cancel()
-                },
-                receiveValue: { value in
-                    continuation.resume(returning: value)
-                    cancellable?.cancel()
+            cancellable = self.sink { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    continuation.resume(throwing: error)
                 }
-            )
+                cancellable?.cancel()
+            }
+            receiveValue: { value in
+                continuation.resume(returning: value)
+                cancellable?.cancel()
+            }
         }
     }
 }

--- a/AGAMI/Sources/Helpers/LottieView.swift
+++ b/AGAMI/Sources/Helpers/LottieView.swift
@@ -41,8 +41,8 @@ enum LottieAnimationType: String {
             "shazamLottie"
         case .export:
             "exportLottie"
-		case .deleting:
-			"deleteLottie"
+        case .deleting:
+            "deleteLottie"
         }
     }
 }

--- a/AGAMI/Sources/Presentation/Model/LoadingPlaceholder/UploadingDataModel.swift
+++ b/AGAMI/Sources/Presentation/Model/LoadingPlaceholder/UploadingDataModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @Observable
-final class ListCellPlaceholderModel {
+final class UploadingDataModel {
     var name: String?
     var streetAddress: String?
     var generationTime: Date?

--- a/AGAMI/Sources/Presentation/View/App/AppContentView.swift
+++ b/AGAMI/Sources/Presentation/View/App/AppContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AppContentView: View {
     @AppStorage("isSignedIn") var isSignedIn: Bool = false
     @State private var sologCoordinator: SologCoordinator = .init()
-    @State private var listCellPlaceholder: ListCellPlaceholderModel = ListCellPlaceholderModel()
+    @State private var uploadingData: UploadingDataModel = UploadingDataModel()
 
     init() { initializeSpotifyService() }
 
@@ -29,7 +29,7 @@ struct AppContentView: View {
                         sologCoordinator.buildFullScreenCover(cover: cover)
                     }
             }
-            .environment(listCellPlaceholder)
+            .environment(uploadingData)
             .environment(sologCoordinator)
 
         } else {

--- a/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
+++ b/AGAMI/Sources/Presentation/View/Search/SearchWritingView.swift
@@ -307,7 +307,7 @@ private struct TopBarLeadingItems: View {
 }
 
 private struct TopbarTrailingItems: View {
-    @Environment(ListCellPlaceholderModel.self) private var placeholderData
+    @Environment(UploadingDataModel.self) private var uploadingData
     @Environment(SologCoordinator.self) private var coordinator
     var viewModel: SearchWritingViewModel
     
@@ -315,7 +315,7 @@ private struct TopbarTrailingItems: View {
         Button {
             Task {
                 viewModel.simpleHaptic()
-                placeholderData.setPropertyValues(
+                uploadingData.setPropertyValues(
                     userTitle: viewModel.playlist.playlistName,
                     streetAddress: viewModel.playlist.streetAddress,
                     generationTime: Date()
@@ -323,7 +323,7 @@ private struct TopbarTrailingItems: View {
                 coordinator.popToRoot()
 
                 if await viewModel.savedPlaylist() {
-                    placeholderData.initializePropertyValues()
+                    uploadingData.initializePropertyValues()
                     viewModel.clearDiggingList()
                 } else {
                     dump("Failed to save playlist. Please try again.")

--- a/AGAMI/Sources/Presentation/View/Solog/SologListView.swift
+++ b/AGAMI/Sources/Presentation/View/Solog/SologListView.swift
@@ -12,7 +12,7 @@ import Kingfisher
 
 struct SologListView: View {
     @State var viewModel: SologListViewModel = SologListViewModel()
-    @Environment(ListCellPlaceholderModel.self) private var listCellPlaceholder
+    @Environment(UploadingDataModel.self) private var uploadingData
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
@@ -47,7 +47,7 @@ struct SologListView: View {
         .onTapGesture(perform: hideKeyboard)
         .onAppearAndActiveCheckUserValued(scenePhase)
         .onAppear(perform: viewModel.fetchPlaylists)
-        .onChange(of: listCellPlaceholder.shouldShowUploadingCell) { oldValue, newValue in
+        .onChange(of: uploadingData.shouldShowUploadingCell) { oldValue, newValue in
             if oldValue == true, newValue == false {
                 viewModel.fetchPlaylists()
             }
@@ -158,7 +158,7 @@ private struct CountingHeaderView: View {
 }
 
 private struct ListView: View {
-    @Environment(ListCellPlaceholderModel.self) private var listCellPlaceholder
+    @Environment(UploadingDataModel.self) private var listCellPlaceholder
     let viewModel: SologListViewModel
     let size: CGSize
     private var verticalSpacingValue: CGFloat { size.width / 377 * 15 }
@@ -287,7 +287,7 @@ private struct NewSologButton: View {
 }
 
 private struct ArchiveListUpLoadingCell: View {
-    @Environment(ListCellPlaceholderModel.self) private var listCellPlaceholder
+    @Environment(UploadingDataModel.self) private var listCellPlaceholder
     let viewModel: SologListViewModel
     let size: CGSize
     private var imageHeight: CGFloat { (size.width - 20) * 157 / 341 }
@@ -397,12 +397,9 @@ private struct ContextMenuItems: View {
             Label("Apple Music에서 열기", systemImage: "square.and.arrow.up")
         }
         Button {
-            viewModel.exportPlaylistToSpotify(playlist: playlist) { result in
-                switch result {
-                case .success(let url):
-                    openURL(url)
-                case .failure(let err):
-                    dump(err.localizedDescription)
+            Task {
+                if let spotifyURL = await viewModel.exportPlaylistToSpotify(playlist: playlist) {
+                    openURL(spotifyURL)
                 }
             }
         } label: {

--- a/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
@@ -507,8 +507,8 @@ private struct MenuContents: View {
         Button {
             viewModel.simpleHaptic()
             Task {
-                if let url = await viewModel.exportPlaylistToAppleMusic() {
-                    openURL(url)
+                if let appleMusicURL = await viewModel.exportPlaylistToAppleMusic() {
+                    openURL(appleMusicURL)
                 }
             }
         } label: {
@@ -517,12 +517,9 @@ private struct MenuContents: View {
         
         Button {
             viewModel.simpleHaptic()
-            viewModel.exportPlaylistToSpotify { result in
-                switch result {
-                case .success(let url):
-                    openURL(url)
-                case .failure(let err):
-                    dump(err)
+            Task {
+                if let spotifyURL = await viewModel.exportPlaylistToSpotify() {
+                    openURL(spotifyURL)
                 }
             }
         } label: {

--- a/AGAMI/Sources/Service/Export/SpotifyService.swift
+++ b/AGAMI/Sources/Service/Export/SpotifyService.swift
@@ -182,7 +182,7 @@ extension SpotifyService {
             state: self.authorizationState
         )
         .receive(on: RunLoop.main)
-        .sink(receiveCompletion: { [weak self] completion in
+        .sink { [weak self] completion in
             guard let self = self else { return }
             self.isRetrievingTokens = false
 
@@ -193,7 +193,7 @@ extension SpotifyService {
                 dump("Spotify: 토큰 갱신 실패\n\(error)")
                 return
             }
-        })
+        }
         .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
## ✅ Description
- `SpotifyService` escaping closure -> Swift Concurrency 리팩토링

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- ### 피드백 없을 시 12.30.(월) 자정에 머지하겠습니다!

- 컨벤션 통일을 위해 `ViewModel` 레이어에서 `await`로 값을 받아 쓸 수 있도록 `SpotifyService` 메소드들의 비동기 처리 방식을 기존 `escaping closure ` 방식에서 `Swift Concurrency`를 이용한 방식으로 수정했습니다.
- 가독성, 유지보수성을 개선하려 노력해 봤는데 `Combine` 등의 반응형 프레임워크에 익숙치 않아 어렵네요,,
    - 여러 예외 케이스 처리가 각기 다른 메소드에 혼재되어 있다고 느껴집니다. 개선점이 보인다면 리뷰 달아주세요 ~~

## 💡 Issue
- Resolved: #278 
