### PR TITLE
[#273] 소록 플레이리스트 뷰, 뷰 모델 수정

### DIFF
--- a/AGAMI/Sources/Presentation/View/Components/ExportingView.swift
+++ b/AGAMI/Sources/Presentation/View/Components/ExportingView.swift
@@ -1,0 +1,23 @@
+//
+//  SwiftUIView.swift
+//  AGAMI
+//
+//  Created by yegang on 1/9/25.
+//
+
+import SwiftUI
+
+struct ExportingView: View {
+    var exportingState: ExportingState
+    
+    var body: some View {
+        switch exportingState {
+        case .isAppleMusicExporting:
+            AppleMusicLottieView()
+        case .isSpotifyExporting:
+            SpotifyLottieView()
+        case .none:
+            EmptyView()
+        }
+    }
+}

--- a/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
@@ -82,21 +82,6 @@ struct SologPlaylistView: View {
     }
 }
 
-private struct ExportingView: View {
-    var exportingState: ExportingState
-    
-    var body: some View {
-        switch exportingState {
-        case .isAppleMusicExporting:
-            AppleMusicLottieView()
-        case .isSpotifyExporting:
-            SpotifyLottieView()
-        case .none:
-            EmptyView()
-        }
-    }
-}
-
 private struct ListView: View {
     let viewModel: SologPlaylistViewModel
     

--- a/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
@@ -468,7 +468,7 @@ private struct TopBarTrailingItems: View {
                             .foregroundStyle(Color(.sMain))
                     }
                 }
-                .disabled(viewModel.presentationState.isUpdating)
+                .disabled(viewModel.presentationState.isSaveButtonDisabled)
             } else if viewModel.exportingState == .none {
                 Button {
                     viewModel.simpleHaptic()

--- a/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
+++ b/AGAMI/Sources/Presentation/View/Solog/SologPlaylistView.swift
@@ -22,14 +22,7 @@ struct SologPlaylistView: View {
         ZStack {
             ListView(viewModel: viewModel)
 
-            switch viewModel.exportingState {
-            case .isAppleMusicExporting:
-                AppleMusicLottieView()
-            case .isSpotifyExporting:
-                SpotifyLottieView()
-            case .none:
-                EmptyView()
-            }
+            ExportingView(exportingState: viewModel.exportingState)
 
             if viewModel.presentationState.isLoading { ProgressView() }
 
@@ -85,6 +78,21 @@ struct SologPlaylistView: View {
             if newScene == .active && viewModel.presentationState.didOpenSpotifyURL {
                 viewModel.resetSpotifyURLState()
             }
+        }
+    }
+}
+
+private struct ExportingView: View {
+    var exportingState: ExportingState
+    
+    var body: some View {
+        switch exportingState {
+        case .isAppleMusicExporting:
+            AppleMusicLottieView()
+        case .isSpotifyExporting:
+            SpotifyLottieView()
+        case .none:
+            EmptyView()
         }
     }
 }

--- a/AGAMI/Sources/Presentation/ViewModel/Solog/SologPlaylistViewModel.swift
+++ b/AGAMI/Sources/Presentation/ViewModel/Solog/SologPlaylistViewModel.swift
@@ -21,6 +21,8 @@ struct PlaylistPresentationState {
     var isShowingExportingAppleMusicFailedAlert: Bool = false
     var isShowingExportingSpotifyFailedAlert: Bool = false
     var didOpenSpotifyURL = false // 백그라운드에서 포그라운드로 돌아왔을 때의 확인 변수
+    
+    var isSaveButtonDisabled: Bool { isUpdating || isLoading }
 }
 
 @Observable


### PR DESCRIPTION
## ✅ Description
- 소록 플레이 리스트 뷰와 뷰 모델 수정했습니다.

## ⭐️ PR Point
<!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
- 기존 `SologPlaylistView` 최상단 뷰 바디 안에 있는 코드를
```swift
private struct ExportingView: View {
    var exportingState: ExportingState
    
    var body: some View {
        switch exportingState {
        case .isAppleMusicExporting:
            AppleMusicLottieView()
        case .isSpotifyExporting:
            SpotifyLottieView()
        case .none:
            EmptyView()
        }
    }
}
```
따로 분리 시켜줬습니다.
분리 시킨 이유는 가장 상단에 있는 뷰에서 코드 길이가 길어진다고 생각해서 따로 빼줬는데 이렇게 할 경우 다시 아래로 내려가서 확인 해야 되니 장단점이 있을 거 같은데 수박은 어떻게 생각하시는지 알려주시면 감사하겠습니다.

---

- SologPlaylistViewModel 에 상태 관리 하는 값을 하나 추가 시켜서 사진이 안전하게 불러와지지 않았을 때 저장 버튼이 눌리지 않게 하려고 했는데, 어떤 부분에서 무엇을 건드려야 될지 모르겠어서 일단 안전하게 하는 방향으로 반창고 붙여놨습니다..

`var isSaveButtonDisabled: Bool { isUpdating || isLoading }` 
- 기존에 disabled는 isUpdating만 확인했었는데 isLoading을 추가 시켜서 앨범에서 사진을 고르는 경우 사진이 안전하게 불러왔을 때 포토 피커가 꺼지고 저장 버튼이 활성화 됩니다.
- 카메라인 경우 사진을 찍고 사진이 안전하게 올라 갔을 경우 저장 버튼이 활성화 됩니다.

---

viewModel에 있는 기능들을 extension 을 통해 비슷한 기능(Service가 같은 경우)들을 묶어줬습니다.
바꾼 이유는 swiftLint에서 250줄 이상 넘어갔을 때 경고 표시가 뜨기도 했고 추후 유지보수 측면에서 찾기 용이하다고 판단 돼서 분리 시켜놨는데 의견이 궁금합니다.

## 📸 Simulator


## 💡 Issue
- Resolved: #273 
